### PR TITLE
Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ More details about the implementation and the mechanisms behind the MMFT Simulat
 
 [[5]](https://doi.org/10.1016/j.simpa.2022.100440) G. Fink, F. Costamoling, and R. Wille. MMFT Droplet Simulator: Efficient Simulation of Droplet-based Microfluidic Devices. Software Impacts, 2022.
 
-[[6]](https://doi.org/10.1109/TCAD.2025.3549703) M. Takken, E. Emmerich, and R. Wille. An Abstract Simulator for Species Concentrations in Channel-Based Microfluidic Devices. IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems (TCAD), 2025.
+[[6]](https://doi.org/10.1109/TCAD.2025.3549703) M. Takken, M. Emmerich, and R. Wille. An Abstract Simulator for Species Concentrations in Channel-Based Microfluidic Devices. IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems (TCAD), 2025.
 
 [[7]](https://doi.org/10.1038/s41598-024-77741-8) M. Emmerich, F. Costamoling, and R. Wille. Modular and Extendable 1D-Simulator for Microfluidic Devices. Scientific Reports, 2024.
 

--- a/examples/Abstract/Continuous/Network1.cpp
+++ b/examples/Abstract/Continuous/Network1.cpp
@@ -53,10 +53,6 @@ int main(int argc, char const* argv []) {
     sim::ResistanceModel1D<T> resistanceModel = sim::ResistanceModel1D<T>(testSimulation.getContinuousPhase()->getViscosity());
     testSimulation.setResistanceModel(&resistanceModel);
 
-    // check if chip is valid
-    network.isNetworkValid();
-    network.sortGroups();
-
     // simulate
     testSimulation.simulate();
 

--- a/examples/Abstract/Droplet/Network1.cpp
+++ b/examples/Abstract/Droplet/Network1.cpp
@@ -59,10 +59,6 @@ int main(int argc, char const* argv []) {
     sim::ResistanceModel1D<T> resistanceModel = sim::ResistanceModel1D<T>(testSimulation.getContinuousPhase()->getViscosity());
     testSimulation.setResistanceModel(&resistanceModel);
 
-    // check if chip is valid
-    network.isNetworkValid();
-    network.sortGroups();
-
     // simulate
     testSimulation.simulate();
 

--- a/examples/Hybrid/Network1a.cpp
+++ b/examples/Hybrid/Network1a.cpp
@@ -79,15 +79,12 @@ int main(int argc, char const* argv []) {
     Openings.try_emplace(9, arch::Opening<T>(network.getNode(9), std::vector<T>({-1.0, 0.0}), 1e-4));
 
     testSimulation.addLbmSimulator(name, stlFile, network.getModule(m0->getId()), Openings, charPhysLength, charPhysVelocity, alpha, resolution, epsilon, tau);
-    network.sortGroups();
 
     // pressure pump
     auto pressure = 1e3;
     network.setPressurePump(c0->getId(), pressure);
     network.setPressurePump(c1->getId(), pressure);
     network.setPressurePump(c2->getId(), pressure);
-
-    network.isNetworkValid();
     
     // Simulate
     testSimulation.setNetwork(&network);

--- a/python/mmft/simulator/CMakeLists.txt
+++ b/python/mmft/simulator/CMakeLists.txt
@@ -2,8 +2,36 @@
 add_subdirectory("${PROJECT_SOURCE_DIR}/external/pybind11" "external/pybind11" EXCLUDE_FROM_ALL)
 
 set(PYTHON_MODULE_NAME "pysimulator")
+
 if(NOT TARGET ${PYTHON_MODULE_NAME})
-	pybind11_add_module(${PYTHON_MODULE_NAME} bindings.cpp)
+	pybind11_add_module(${PYTHON_MODULE_NAME} 
+
+		# Architecture bindings
+		arch/bind_channel.cpp
+		arch/bind_edge.cpp
+		arch/bind_enums.cpp
+		arch/bind_membrane.cpp
+		arch/bind_module.cpp
+		arch/bind_network.cpp
+		arch/bind_node.cpp
+		arch/bind_opening.cpp
+		arch/bind_pumps.cpp
+		arch/bind_tank.cpp
+
+		# Simulator bindings
+		sim/bind_abstractContinuous.cpp
+		sim/bind_abstractDroplet.cpp
+		sim/bind_abstractMembrane.cpp
+		sim/bind_abstractMixing.cpp
+		sim/bind_droplet.cpp
+		sim/bind_fluid.cpp
+		sim/bind_hybridContinuous.cpp
+		sim/bind_injections.cpp
+		sim/bind_mixture.cpp
+		sim/bind_simulation.cpp
+		sim/bind_specie.cpp
+		
+	)
 	target_link_libraries(${PYTHON_MODULE_NAME} PRIVATE simLib)
 	target_compile_definitions(${PYTHON_MODULE_NAME} PRIVATE VERSION_INFO=${SIMULATOR_VERSION_INFO})
 endif()

--- a/python/mmft/simulator/arch/bind_channel.cpp
+++ b/python/mmft/simulator/arch/bind_channel.cpp
@@ -1,0 +1,36 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+
+namespace py = pybind11;
+using T = double;
+
+void bind_channel(py::module_& m) {
+
+	py::class_<arch::Channel<T>, arch::Edge<T>, py::smart_holder>(m, "Channel")
+		.def("setChannelType", &arch::Channel<T>::setChannelType, "Set the type of channel.")
+		.def("getChannelShape", &arch::Channel<T>::getChannelShape, "Returns the shape of the channel cross section.")
+		.def("getChannelType", &arch::Channel<T>::getChannelType, "Returns the type of the channel.")
+		.def("setLength", &arch::Channel<T>::setLength, "Set the length of the channel [m].")
+		.def("getLength", &arch::Channel<T>::getLength, "Returns the length of the channel [m].")
+		.def("getArea", &arch::Channel<T>::getArea, "Returns the area of the channel cross-section [m^2].")
+		.def("getVolume", &arch::Channel<T>::getVolume, "Returns the volume of the channel [m^3].")
+		.def("isChannelValid", &arch::Channel<T>::isChannelValid, "Returns true if the channel parameters are valid.")
+		.def("isRectangular", &arch::Channel<T>::isRectangular, "Returns true if the channel has a rectangular cross-section.")
+		.def("isCylindrical", &arch::Channel<T>::isCylindrical, "Returns true if the channel has a cylindrical cross-section.");
+
+	py::class_<arch::RectangularChannel<T>, arch::Channel<T>, py::smart_holder>(m, "RectangularChannel")
+		.def("get2DFlowRate", &arch::RectangularChannel<T>::get2DFlowRate, "Maps and returns the 2-dimensional flow rate within the channel [m^2/s].")
+		.def("setWidth", &arch::RectangularChannel<T>::setWidth, "Set the width of the channel cross-section [m].")
+		.def("getWidth", &arch::RectangularChannel<T>::getWidth, "Returns the width of the channel cross-section [m].")
+		.def("setHeight", &arch::RectangularChannel<T>::setHeight, "Set the height of the channel cross-section [m].")
+		.def("getHeight", &arch::RectangularChannel<T>::getHeight, "Returns the height of the channel cross-section [m]");
+
+	py::class_<arch::CylindricalChannel<T>, arch::Channel<T>, py::smart_holder>(m, "CylindricalChannel")
+		.def("setRadius", &arch::CylindricalChannel<T>::setRadius, "Set the radius of the channel cross-section [m].")
+		.def("getRadius", &arch::CylindricalChannel<T>::getRadius, "Returns the radius of the channel cross-section [m].");
+
+}

--- a/python/mmft/simulator/arch/bind_edge.cpp
+++ b/python/mmft/simulator/arch/bind_edge.cpp
@@ -1,0 +1,22 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Edge.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_edge(py::module_& m) {
+
+	py::class_<arch::Edge<T>, py::smart_holder>(m, "Edge")
+		.def("getId", &arch::Edge<T>::getId, "Returns the Id of the edge.")
+		.def("getNodeAId", &arch::Edge<T>::getNodeAId, "Returns the id of the node at the start of the edge.")
+		.def("getNodeBId", &arch::Edge<T>::getNodeBId, "Returns the id of the node at the end of the edge.")
+		.def("getNodeIds", &arch::Edge<T>::getNodeIds, "Returns the ids of the edge's nodes.")
+		.def("getPressure", &arch::Edge<T>::getPressure, "Returns the pressure of the edge [Pa].")
+		.def("getFlowRate", &arch::Edge<T>::getFlowRate, "Returns the flow rate within the edge [m^3/s].")
+		.def("getResistance", &arch::Edge<T>::getResistance, "Returns the inherent resistance of the edge [Pa s].");
+
+}

--- a/python/mmft/simulator/arch/bind_enums.cpp
+++ b/python/mmft/simulator/arch/bind_enums.cpp
@@ -1,0 +1,35 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Module.h"
+#include "simulation/simulators/Simulation.h"
+#include "simulation/simulators/CFDSim.h"
+#include "simulation/simulators/HybridContinuous.h"
+#include "simulation/simulators/cfdHandlers/cfdSimulator.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_enums(py::module_& m) {
+
+	py::enum_<arch::ChannelType>(m, "ChannelType")
+		.value("normal", arch::ChannelType::NORMAL)
+		.value("bypass", arch::ChannelType::BYPASS)
+		.value("cloggable", arch::ChannelType::CLOGGABLE);
+
+	py::enum_<arch::ModuleType>(m, "ModuleType")
+		.value("normal", arch::ModuleType::NORMAL)
+		.value("lbm", arch::ModuleType::LBM);
+
+	py::enum_<sim::Type>(m, "Type")
+		.value("abstract", sim::Type::Abstract)
+		.value("hybrid", sim::Type::Hybrid);
+
+	py::enum_<sim::Platform>(m, "Platform")
+		.value("continuous", sim::Platform::Continuous)
+		.value("bigDroplet", sim::Platform::BigDroplet);
+
+}

--- a/python/mmft/simulator/arch/bind_membrane.cpp
+++ b/python/mmft/simulator/arch/bind_membrane.cpp
@@ -1,0 +1,38 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Edge.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_membrane(py::module_& m) {
+
+	py::class_<arch::Membrane<T>, arch::Edge<T>, py::smart_holder>(m, "Membrane")
+		.def("setDimensions", &arch::Membrane<T>::setDimensions, "Set the dimensions of the membrane [w, h, l] [m].")
+		.def("setHeight", &arch::Membrane<T>::setHeight, "Set the height of the membrane [m].")
+		.def("setWidth", &arch::Membrane<T>::setWidth, "Set the width of the membrane [m].")
+		.def("setLength", &arch::Membrane<T>::setLength, "Set the length of the membrane [m].")
+		.def("setPoreRadius", &arch::Membrane<T>::setPoreRadius, "Set the pore radius of the pores of the membrane [m].")
+		.def("setPorosity", &arch::Membrane<T>::setPorosity, "Set the porosity of the membrane [0.0-1.0].")
+		.def("setChannel", &arch::Membrane<T>::setChannel, "Set the channel the membrane is connected to.")
+		.def("setTank", &arch::Membrane<T>::setTank, "Set the tank the membrane is connected to.")
+		.def("getConcentrationChange", &arch::Membrane<T>::getConcentrationChange, "Returns the concentration change caused by the membrane [mol].")
+		.def("getHeight", &arch::Membrane<T>::getHeight, "Returns the height of the membrane [m].")
+		.def("getWidth", &arch::Membrane<T>::getWidth, "Returns the width of the membrane [m].")
+		.def("getLength", &arch::Membrane<T>::getLength, "Returns the length of the membrane [m].")
+		.def("getChannel", &arch::Membrane<T>::getChannel, "Returns the channel that the membrane is connected to.")
+		.def("getRectangularChannel", &arch::Membrane<T>::getRectangularChannel, "Returns the rectangular channel that the membrane is connected to.")
+		.def("getTank", &arch::Membrane<T>::getTank, "Returns the tank that the membrane is connected to.")
+		.def("getPoreRadius", &arch::Membrane<T>::getPoreRadius, "Returns the pore radius of the membrane [m].")
+		.def("getPoreDiameter", &arch::Membrane<T>::getPoreDiameter, "Returns the diameter of the pores of the membrane [m].")
+		.def("getPorosity", &arch::Membrane<T>::getPorosity, "Returns the porosity of the membrane [0.0-1.0].")
+		.def("getNumberOfPores", &arch::Membrane<T>::getNumberOfPores, "Returns the number of pores in a given area [m^2] of the membrane.")
+		.def("getPoreDensity", &arch::Membrane<T>::getPoreDensity, "Returns the density of the pores in the membrane.")
+		.def("getArea", &arch::Membrane<T>::getArea, "Returns the area of the membrane [m^2].")
+		.def("getVolume", &arch::Membrane<T>::getVolume, "Returns the volume of the membrane [m^3].");
+
+}

--- a/python/mmft/simulator/arch/bind_module.cpp
+++ b/python/mmft/simulator/arch/bind_module.cpp
@@ -1,0 +1,35 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Module.h"
+#include "architecture/entities/Node.h"
+#include "architecture/entities/PressurePump.h"
+#include "architecture/entities/Tank.h"
+#include "architecture/definitions/ModuleOpening.h"
+#include "architecture/Network.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_module(py::module_& m) {
+
+	py::class_<arch::Module<T>, py::smart_holder>(m, "Module")
+		.def("getId", &arch::Module<T>::getId, "Returns the id of the module.")
+		.def("getPosition", &arch::Module<T>::getPosition, "Returns the position [x, y] of the bottom left corner w.r.t. the device [m].")
+		.def("getSize", &arch::Module<T>::getSize, "Returns the size [x, y] of the module [m].")
+		.def("getNodes", &arch::Module<T>::getNodes, "Returns a map of nodes that are on the module's edges.")
+		.def("getModuleType", &arch::Module<T>::getModuleType, "Returns the type of the module.");
+
+	py::class_<arch::CfdModule<T>, arch::Module<T>, py::smart_holder>(m, "CfdModule")
+		.def("assertInitialized", &arch::CfdModule<T>::assertInitialized, "Checks whether the CFD module has valid openings and STL definitions.")
+		.def("getNetwork", &arch::CfdModule<T>::getNetwork, "Returns a graph network that fully connects the module's boundary nodes.")
+		.def("getOpenings", &arch::CfdModule<T>::getOpenings, "Returns a map of the openings of the module.")
+		.def("getStlFile", &arch::CfdModule<T>::getStlFile, "Returns the STL file that defines the CFD domain.");
+
+}

--- a/python/mmft/simulator/arch/bind_network.cpp
+++ b/python/mmft/simulator/arch/bind_network.cpp
@@ -1,0 +1,130 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Module.h"
+#include "architecture/entities/Node.h"
+#include "architecture/entities/PressurePump.h"
+#include "architecture/entities/Tank.h"
+#include "architecture/definitions/ModuleOpening.h"
+#include "architecture/Network.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_network(py::module_& m) {
+
+	py::class_<arch::Network<T>, py::smart_holder>(m, "Network")
+		.def("isNetworkValid", &arch::Network<T>::isNetworkValid, "Check if the current network is valid.")
+		.def("toJson", &arch::Network<T>::toJson, "Store the network object in a JSON file.")
+		.def("print", &arch::Network<T>::print, "Print the content of this network.")
+		// Nodes
+		.def("addNode", py::overload_cast<T, T, bool>(&arch::Network<T>::addNode), 
+			py::arg("x"), py::arg("y"), py::arg("ground")=false, "Add a new node to the network.")
+		.def("getNode", &arch::Network<T>::getNode, "Returns the node with the given id.")
+		.def("getNodes", &arch::Network<T>::getNodes, "Returns all nodes in the network.")
+		.def("getGroundNodes", &arch::Network<T>::getGroundNodes, "Returns the set of nodes that are ground nodes.")
+		.def("getGroundNodeIds", &arch::Network<T>::getGroundNodeIds, "Returns the ids of the set of ground nodes.")
+		.def("getVirtualNodes", &arch::Network<T>::getVirtualNodes, "Returns the amount of virtual nodes in the network.")
+		.def("setVirtualNodes", &arch::Network<T>::setVirtualNodes, "Sets the amount of virtual nodes in the network.")
+		.def("hasNode", py::overload_cast<size_t>(&arch::Network<T>::hasNode, py::const_), "Returns true if the network contains the node with the given id.")
+		.def("hasNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::hasNode, py::const_), "Returns true if the network contains the given node.")
+		.def("setSink", py::overload_cast<size_t>(&arch::Network<T>::setSink), "Sets the node with given id to be a sink node.")
+		.def("setSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::setSink), "Sets the given node to be a sink node.")
+		.def("isSink", py::overload_cast<size_t>(&arch::Network<T>::isSink, py::const_), "Returns true if the node of the given id is a sink node.")
+		.def("isSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isSink, py::const_), "Returns true if the given node is a sink node.")
+		.def("setGround", py::overload_cast<size_t>(&arch::Network<T>::setGround), "Sets the node with given id to be a ground node.")
+		.def("setGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::setGround), "Sets the given node to be a ground node.")
+		.def("isGround", py::overload_cast<size_t>(&arch::Network<T>::isGround, py::const_), "Returns true if the node of the given id is a ground node.")
+		.def("isGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isGround, py::const_), "Returns true if the given node is a ground node.")
+		.def("calculateNodeDistance", py::overload_cast<size_t, size_t>(&arch::Network<T>::calculateNodeDistance, py::const_), 
+			"Calculates the Euclidean distance between the nodes of the given ids.")
+		.def("calculateNodeDistance", py::overload_cast<std::shared_ptr<arch::Node<T>>, std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::calculateNodeDistance, py::const_), 
+			"Calculates the Euclidean distance between the two given nodes.")
+		.def("removeNode", &arch::Network<T>::removeNode, "Removes the given node from the network.")
+		// Channels
+		.def("addRectangularChannel", py::overload_cast<size_t, size_t, T, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&, T, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<size_t, size_t, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<size_t, size_t, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("getChannel", &arch::Network<T>::getChannel, "Returns the channel with the given id.")
+		.def("getRectangularChannel", &arch::Network<T>::getRectangularChannel, "Returns the channel with the given id, if it is a rectangular channel.")
+		.def("getChannels", &arch::Network<T>::getChannels, "Returns all channels in the network.")
+		.def("getChannelsAtNode", py::overload_cast<size_t>(&arch::Network<T>::getChannelsAtNode, py::const_), 
+				"Returns all channels in the network that are connected to the node with the given id.")
+		.def("getChannelsAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getChannelsAtNode, py::const_), 
+			"Returns all channels in the network that are connected to the given node.")
+		.def("isChannel", py::overload_cast<int>(&arch::Network<T>::isChannel, py::const_), "Returns true if the edge with the given id is a channel.")
+		.def("isChannel", py::overload_cast<const std::shared_ptr<arch::Edge<T>>&>(&arch::Network<T>::isChannel, py::const_), "Returns true if the given edge is a channel.")
+		.def("removeChannel", &arch::Network<T>::removeChannel, "Remove the given channel from the network.")
+		// Pumps
+		.def("addFlowRatePump", &arch::Network<T>::addFlowRatePump, "Add a flow rate pump to the network.")
+		.def("getFlowRatePump", &arch::Network<T>::getFlowRatePump, "Returns the flow rate pump with the given id.")
+		.def("setFlowRatePump", &arch::Network<T>::setFlowRatePump, "Set the edge with the given id to be a flow rate pump.")
+		.def("isFlowRatePump", &arch::Network<T>::isFlowRatePump, "Returns true if the provided edge id is from a flow rate pump.")
+		.def("getFlowRatePumps", &arch::Network<T>::getFlowRatePumps, "Returns all flow rate pumps in the network.")
+		.def("removeFlowRatePump", &arch::Network<T>::removeFlowRatePump, "Removes the given flow rate pump from the network.")
+		.def("addPressurePump", &arch::Network<T>::addPressurePump, "Add a pressure pump to the network.")
+		.def("getPressurePump", &arch::Network<T>::getPressurePump, "Returns the pressure pump with the given id.")
+		.def("setPressurePump", &arch::Network<T>::setPressurePump, "Set the edge with the given id to be a pressure pump.")
+		.def("isPressurePump", &arch::Network<T>::isPressurePump, "Returns true if the provided edge id is from a pressure pump.")
+		.def("getPressurePumps", &arch::Network<T>::getPressurePumps, "Returns all pressure pumps in the network.")
+		.def("removePressurePump", &arch::Network<T>::removePressurePump, "Removes the given pressure pump from the network.")
+		// Modules
+		.def("addCfdModule", &arch::Network<T>::addCfdModule, "Adds a CFD module to the network.")
+		.def("getCfdModule", &arch::Network<T>::getCfdModule, "Returns the CFD module with the given id.")
+		.def("getCfdModules", &arch::Network<T>::getCfdModules, "Returns all CFD modules in the network.")
+		.def("removeModule", &arch::Network<T>::removeModule, "Removes the given module from the network")
+		// Membrane
+		.def("addMembraneToChannel", py::overload_cast<size_t, T, T, T, T>(&arch::Network<T>::addMembraneToChannel), "Adds a membrane to a channel in the network.")
+		.def("addMembraneToChannel", py::overload_cast<const std::shared_ptr<arch::Channel<T>>&, T, T, T, T>(&arch::Network<T>::addMembraneToChannel), 
+			"Adds a membrane to a channel in the network.")
+		.def("getMembrane", &arch::Network<T>::getMembrane, "Returns the membrane with the given id.")
+		.def("getMembraneBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getMembraneBetweenNodes, py::const_), 
+			"Returns the membrane between two given nodes.")
+		.def("getMembraneBetweenNodes", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&>(&arch::Network<T>::getMembraneBetweenNodes, py::const_), 
+			"Returns the membrane between two given nodes.")
+		.def("getMembranes", &arch::Network<T>::getMembranes, "Returns all membranes in the network.")
+		.def("getMembranesAtNode", py::overload_cast<size_t>(&arch::Network<T>::getMembranesAtNode, py::const_), 
+			"Returns the set of membranes that are at the given node.")
+		.def("getMembranesAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getMembranesAtNode, py::const_), 
+			"Returns the set of membranes that are at the given node.")
+		.def("isMembrane", &arch::Network<T>::isMembrane, "Returns true if the given edge id belongs to a membrane.")
+		// Tank
+		.def("addTankToMembrane", py::overload_cast<size_t, T, T>(&arch::Network<T>::addTankToMembrane), "Adds a tank to a membrane in the network.")
+		.def("addTankToMembrane", py::overload_cast<const std::shared_ptr<arch::Membrane<T>>&, T, T>(&arch::Network<T>::addTankToMembrane), 
+			"Adds a tank to a membrane in the network.")
+		.def("getTank", &arch::Network<T>::getTank, "Returns the tank with the given id.")
+		.def("getTankBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getTankBetweenNodes, py::const_), 
+			"Returns the tank between two given nodes.")
+		.def("getTankBetweenNodes", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&>(&arch::Network<T>::getTankBetweenNodes, py::const_), 
+			"Returns the tank between two given nodes.")
+		.def("getTanks", &arch::Network<T>::getTanks, "Returns all tanks in the network.");
+		
+	m.def("createNetwork", py::overload_cast<>(&arch::Network<T>::createNetwork), "Create a Network object.");
+	m.def("createNetwork", py::overload_cast<std::unordered_map<size_t, std::shared_ptr<arch::Node<T>>>>
+		(&arch::Network<T>::createNetwork), "Create a Network object.");
+	m.def("createNetwork", py::overload_cast<std::unordered_map<size_t, std::shared_ptr<arch::Node<T>>>, 
+											std::unordered_map<size_t, std::shared_ptr<arch::Channel<T>>>>
+		(&arch::Network<T>::createNetwork), "Create a Network object.");
+	m.def("createNetwork", py::overload_cast<std::unordered_map<size_t, std::shared_ptr<arch::Node<T>>>, 
+                                            std::unordered_map<size_t, std::shared_ptr<arch::Channel<T>>>,
+                                            std::unordered_map<size_t, std::shared_ptr<arch::FlowRatePump<T>>>,
+                                            std::unordered_map<size_t, std::shared_ptr<arch::PressurePump<T>>>,
+                                            std::unordered_map<size_t, std::shared_ptr<arch::CfdModule<T>>>>
+		(&arch::Network<T>::createNetwork), "Create a Network object.");
+
+}

--- a/python/mmft/simulator/arch/bind_node.cpp
+++ b/python/mmft/simulator/arch/bind_node.cpp
@@ -1,0 +1,23 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Node.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_node(py::module_& m) {
+
+	py::class_<arch::Node<T>, py::smart_holder>(m, "Node")
+		.def("getId", &arch::Node<T>::getId, "Returns the Id of the node.")
+		.def("setPosition", &arch::Node<T>::setPosition, "Set the position of the node.")
+		.def("getPosition", &arch::Node<T>::getPosition, "Returns the position of the node.")
+		.def("getPressure", &arch::Node<T>::getPressure, "Returns the pressure at the node.")
+		.def("setSink", &arch::Node<T>::setSink, "Set the node as a sink node.")
+		.def("getSink", &arch::Node<T>::getSink, "Returns true if the node is a sink node.")
+		.def("setGround", &arch::Node<T>::setGround, "Set the node as a ground node.")
+		.def("getGround", &arch::Node<T>::getGround, "Returns true if the node is a ground node.");
+
+}

--- a/python/mmft/simulator/arch/bind_opening.cpp
+++ b/python/mmft/simulator/arch/bind_opening.cpp
@@ -1,0 +1,24 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Node.h"
+#include "architecture/definitions/ModuleOpening.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_opening(py::module_& m) {
+
+	py::class_<arch::Opening<T>>(m, "Opening")
+        .def(py::init<std::shared_ptr<arch::Node<T>>, std::vector<T>, T,T>(),
+            py::arg("node"), py::arg("normal"), py::arg("width"), py::arg("height") = 1e-4)
+		.def_readwrite("node", &arch::Opening<T>::node)
+		.def_readwrite("normal", &arch::Opening<T>::normal)
+		.def_readwrite("tangent", &arch::Opening<T>::tangent)
+		.def_readwrite("width", &arch::Opening<T>::width)
+		.def_readwrite("height", &arch::Opening<T>::height)
+		.def_readwrite("radial", &arch::Opening<T>::radial);
+
+}

--- a/python/mmft/simulator/arch/bind_pumps.cpp
+++ b/python/mmft/simulator/arch/bind_pumps.cpp
@@ -1,0 +1,21 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/PressurePump.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_pumps(py::module_& m) {
+
+	py::class_<arch::FlowRatePump<T>, arch::Edge<T>, py::smart_holder>(m, "FlowRatePump")
+		.def("setFlowRate", &arch::FlowRatePump<T>::setFlowRate, "Set the flow rate of the pump [m^3/s].");
+
+	py::class_<arch::PressurePump<T>, arch::Edge<T>, py::smart_holder>(m, "PressurePump")
+		.def("setPressure", &arch::PressurePump<T>::setPressure, "Set the pressure across the pump [Pa].");
+
+}

--- a/python/mmft/simulator/arch/bind_tank.cpp
+++ b/python/mmft/simulator/arch/bind_tank.cpp
@@ -1,0 +1,25 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/Tank.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_tank(py::module_& m) {
+
+	py::class_<arch::Tank<T>, arch::Edge<T>, py::smart_holder>(m, "Tank")
+		.def("setDimensions", &arch::Tank<T>::setDimensions, "Set the dimensions of the tank [w, h, l] [m].")
+		.def("setHeight", &arch::Tank<T>::setHeight, "Set the height of the tank [m].")
+		.def("setWidth", &arch::Tank<T>::setWidth, "Set the width of the tank [m].")
+		.def("setLength", &arch::Tank<T>::setLength, "Set the length of the tank [m].")
+		.def("getHeight", &arch::Tank<T>::getHeight, "Returns the height of the tank [m].")
+		.def("getWidth", &arch::Tank<T>::getWidth, "Returns the width of the tank [m].")
+		.def("getLength", &arch::Tank<T>::getLength, "Returns the length of the tank [m].")
+		.def("getArea", &arch::Tank<T>::getArea, "Returns the area of the tank [m^2].")
+		.def("getVolume", &arch::Tank<T>::getVolume, "Returns the volume of the tank [m^3].");
+
+}

--- a/python/mmft/simulator/bindings.cpp
+++ b/python/mmft/simulator/bindings.cpp
@@ -131,7 +131,6 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getPosition", &arch::Module<T>::getPosition, "Returns the position [x, y] of the bottom left corner w.r.t. the device [m].")
 		.def("getSize", &arch::Module<T>::getSize, "Returns the size [x, y] of the module [m].")
 		.def("getNodes", &arch::Module<T>::getNodes, "Returns a map of nodes that are on the module's edges.")
-		.def("setModuleTypeLbm", &arch::Module<T>::setModuleTypeLbm, "Set the type of the module to lbm simulator.")
 		.def("getModuleType", &arch::Module<T>::getModuleType, "Returns the type of the module.");
 
 	py::class_<arch::CfdModule<T>, arch::Module<T>, py::smart_holder>(m, "CfdModule")
@@ -285,29 +284,25 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getId", &sim::Mixture<T>::getId, "Returns the id of the mixture.")
 		.def("getName", &sim::Mixture<T>::getName, "Returns the name of the mixture.")
 		.def("setName", &sim::Mixture<T>::setName, "Sets the name of the mixture.")
-		//.def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("addSpecie", py::overload_cast<std::shared_ptr<sim::Specie<T>>&, T>(&sim::Mixture<T>::addSpecie), 
-			"Adds a specie with a given concentration to this mixture.")
-		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("readSpecieConcentrations", &sim::Mixture<T>::readSpecieConcentrations, "Returns a read-only map of the specie concentrations.")
-		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		.def("addSpecie", &sim::Mixture<T>::addSpecie, "Adds a specie with a given concentration to this mixture.")
+		.def("getSpecie", &sim::Mixture<T>::getSpecie, "Returns the specie with the given id from this mixture, together with the concentration.")
+		.def("getSpecies", &sim::Mixture<T>::getSpecie, "Returns the specie from this mixture, with the given id.")
+		.def("getSpecieConcentrations", &sim::Mixture<T>::getSpecieConcentrations, "Returns a map of the specie concentrations.")
 		.def("getConcentrationOfSpecie", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::Mixture<T>::getConcentrationOfSpecie, py::const_), 
-			"Returns the concentration of a specie [TODO].")
-		.def("getSpecieDistributions", py::overload_cast<>(&sim::Mixture<T>::getSpecieDistributions, py::const_), 
-			"Returns the concentration distribution of a species if it's not a constant value [TODO].")
-		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("setSpecieConcentration", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::Mixture<T>::setSpecieConcentration), "Sets the concentration of a specie [TODO].")
+			"Returns the concentration of a specie [g/m^3].")
+		.def("getSpecieDistributions", &sim::Mixture<T>::getSpecieDistributions, "Returns the concentration distributions of all species if it's not a constant value [g/m^3].")
+		.def("setSpecieConcentration", &sim::Mixture<T>::setSpecieConcentration, "Sets the concentration of a specie [g/m^3].")
 		.def("getSpecieCount", &sim::Mixture<T>::getSpecieCount, "Returns the number of species listed in the mixture.")
-		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("removeSpecie", py::overload_cast<std::shared_ptr<sim::Specie<T>>&>(&sim::Mixture<T>::removeSpecie), "Removes a specie from the mixture.")
+		.def("removeSpecie", &sim::Mixture<T>::removeSpecie, "Removes a specie from the mixture.")
 		.def("getDensity", &sim::Mixture<T>::getDensity, "Returns the density of the mixture [kg/m^3].")
 		.def("getViscosity", &sim::Mixture<T>::getViscosity, "Returns the viscosity of the mixture [Pa s].")
-		.def("getLargestMolecularSize", &sim::Mixture<T>::getLargestMolecularSize, "Returns the largest molecular size of the species in the mixture.");
+		.def("getLargestMolecularSize", &sim::Mixture<T>::getLargestMolecularSize, "Returns the largest molecular size of the species in the mixture [m^3].");
 
 	py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
 		.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
-		.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.");
+		.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.")
+		.def("getDistributionOfSpecie",  py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::DiffusiveMixture<T>::getDistributionOfSpecie, py::const_), 
+			"Returns the concentration distribution of a species if it's not a constant value [g/m^3].");
 
 	py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
 		.def("getId", &sim::DropletInjection<T>::getId, "Returns the id of the droplet injection.")
@@ -315,9 +310,10 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("setName", &sim::DropletInjection<T>::setName, "Sets the name of the droplet inkection.")
 		.def("getInjectionTime", &sim::DropletInjection<T>::getInjectionTime, "Returns the time at which the droplet is injected [s].")
 		.def("setInjectionTime", &sim::DropletInjection<T>::setInjectionTime, "Sets the time at which the droplet should be injected [s].")
-		// Encapsulation -> Why do we set and return the ChannelPosition object, and not just channel and position parameters?
-		.def("getInjectionPosition", &sim::DropletInjection<T>::getInjectionPosition, "Returns the channel and position at which the droplet is injected.")
-		.def("setInjectionPosition", &sim::DropletInjection<T>::setInjectionPosition, "Sets the channel and position at which the droplet is injected.");
+		.def("getInjectionPosition", &sim::DropletInjection<T>::getInjectionPosition, "Returns the relative channel position at which the droplet is injected [0.0-1.0].")
+		.def("setInjectionPosition", &sim::DropletInjection<T>::setInjectionPosition, "Sets the relative channel position at which the droplet is injected [0.0-1.0].")
+		.def("getInjectionChannel", &sim::DropletInjection<T>::getInjectionPosition, "Returns the channel into which the droplet is injected.")
+		.def("setInjectionChannel", &sim::DropletInjection<T>::setInjectionPosition, "Sets the channel into which the droplet is injected.");
 
 	py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
 		.def("getId", &sim::MixtureInjection<T>::getId, "Returns the id of the mixture injection.")
@@ -332,21 +328,15 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
 		.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
 		.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
-		// .def("getInitialized", &sim::CFDSimulator<T>::getInitialized, "Returns whether the simulator is initialized or not.")
-		// .def("setInitialized", &sim::CFDSimulator<T>::, "")
 		.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
 		.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
 		.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
 		.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
-		// .def("storeConcentrations", &sim::CFDSimulator<T>::, "")
-		// .def("getConcentrations", &sim::CFDSimulator<T>::, "")
-		// .def("setBoundaryValues", &sim::CFDSimulator<T>::, "")
 		.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
 		.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
 		.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
 		.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
 		.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.");
-		// .def("storeCfdResults", &sim::CFDSimulator<T>::, "");
 
 	py::class_<sim::lbmSimulator<T>, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
 		.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
@@ -368,8 +358,6 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
 		.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
 		.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
-		// .def("addMixedFluid", py::overload_cast<int, T, int, T>(&sim::Simulation<T>::addMixedFluid), 
-			// "Creates and adds a new fluid from two existing fluids.")
 		.def("addMixedFluid", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&, T, const std::shared_ptr<sim::Fluid<T>>&, T>(&sim::Simulation<T>::addMixedFluid), 
 			"Creates and adds a new fluid from two existing fluids.")
 		.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
@@ -430,9 +418,7 @@ PYBIND11_MODULE(pysimulator, m) {
 				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
 				return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
 			}))
-		// .def("setPermeabilityMembraneModel", &sim::AbstractMembrane<T>::setPermeabilityMembraneModel, "Sets the permeability membrane model.")
-		// .def("setPoreResistanceMembraneModel", &sim::AbstractMembrane<T>::setPoreResistanceMembraneModel, "Sets the pore resistance membrane model.")
-		// .def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
+		.def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
 		.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
 		.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
 		.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")

--- a/python/mmft/simulator/bindings.cpp
+++ b/python/mmft/simulator/bindings.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
 #include <baseSimulator.h>
@@ -20,6 +21,10 @@ PYBIND11_MODULE(pysimulator, m) {
 		.value("bypass", arch::ChannelType::BYPASS)
 		.value("cloggable", arch::ChannelType::CLOGGABLE);
 
+	py::enum_<arch::ModuleType>(m, "ModuleType")
+		.value("normal", arch::ModuleType::NORMAL)
+		.value("lbm", arch::ModuleType::LBM);
+
 	py::enum_<sim::Type>(m, "Type")
 		.value("abstract", sim::Type::Abstract)
 		.value("hybrid", sim::Type::Hybrid);
@@ -28,129 +33,459 @@ PYBIND11_MODULE(pysimulator, m) {
 		.value("continuous", sim::Platform::Continuous)
 		.value("bigDroplet", sim::Platform::BigDroplet);
 
-	py::class_<arch::Network<T>>(m, "Network")
-		.def(py::init<>())
-		.def("sort", &arch::Network<T>::sortGroups, "Sort the nodes, channels and modules of the network.")
-		.def("valid", &arch::Network<T>::isNetworkValid, "Check if the current network is valid.")
-		.def("addNode", [](arch::Network<T> &network, T x, T y, bool ground) {
-			return network.addNode(x, y, ground)->getId();
-			}, "Add a new node to the network.")
-		.def("addNode", [](arch::Network<T> &network, T x, T y, bool ground, bool sink) {
-			int id = network.addNode(x, y, ground)->getId();
-			network.setSink(id);
-			return id;
-			}, "Add a new node to the network.")
-		.def("addChannel", [](arch::Network<T> &network, int nodeAId, int nodeBId, T width, T height, arch::ChannelType type) {
-			return network.addChannel(nodeAId, nodeBId, height, width, type)->getId();
-			}, "Add a new channel to the network.")
-		.def("addFlowRatePump", [](arch::Network<T> &network, int nodeAId, int nodeBId, T flowRate) {
-			return network.addFlowRatePump(nodeAId, nodeBId, flowRate)->getId();
-			}, "Add a new flow rate pump to the network.")
-		.def("setFlowRatePump", &arch::Network<T>::setFlowRatePump, "Turn a channel into a flow rate pump with given flow rate.")
-		.def("addPressurePump", [](arch::Network<T> &network, int nodeAId, int nodeBId, T pressure) {
-			return network.addPressurePump(nodeAId, nodeBId, pressure)->getId();
-			}, "Add a new pressure pump to the network.")
-		.def("setPressurePump", &arch::Network<T>::setPressurePump, "Turn a channel into a pressure pump with given pressure.")
-		.def("addModule", [](arch::Network<T> &network,
-								std::vector<T> position,
-								std::vector<T> size,
-								std::vector<int> nodes) {
+	py::class_<arch::Opening>(m, "Opening")
+        .def(py::init<std::shared_ptr<NodeT>, std::vector<T>, T,T>(),
+            py::arg("node"), py::arg("normal"), py::arg("width"), py::arg("height") = 1e-4)
+		.def_readwrite("node", &arch::Opening::node)
+		.def_readwrite("normal", &arch::Opening::normal)
+		.def_readwrite("tangent", &arch::Opening::tangent)
+		.def_readwrite("width", &arch::Opening::width)
+		.def_readwrite("height", &arch::Opening::height)
+		.def_readwrite("radial", &arch::Opening::radial)
 
-			std::unordered_map<int, std::shared_ptr<arch::Node<T>>> newNodes;
+	py::class_<arch::Node<T>, py::smart_holder>(m, "Node")
+		.def("getId", &arch::Node<T>::getId, "Returns the Id of the node.")
+		.def("setPosition", &arch::Node<T>::setPosition, "Set the position of the node.")
+		.def("getPosition", &arch::Node<T>::getPosition, "Returns the position of the node.")
+		.def("getPressure", &arch::Node<T>::getPressure, "Returns the pressure at the node.")
+		.def("setSink", &arch::Node<T>::setSink, "Set the node as a sink node.")
+		.def("getSink", &arch::Node<T>::getSink, "Returns true if the node is a sink node.")
+		.def("setGround", &arch::Node<T>::setGround, "Set the node as a ground node.")
+		.def("getGround", &arch::Node<T>::getGround, "Returns true if the node is a ground node.");
 
-			for (long unsigned int i=0; i<nodes.size(); ++i) {
-				newNodes.try_emplace(nodes[i], network.getNode(nodes[i]));
-			}
+	py::class_<arch::Edge<T>, py::smart_holder>(m, "Edge")
+		.def("getId", &arch::Edge<T>::getId, "Returns the Id of the edge.")
+		.def("getNodeAId", &arch::Edge<T>::getNodeAId, "Returns the id of the node at the start of the edge.")
+		.def("getNodeBId", &arch::Edge<T>::getNodeBId, "Returns the id of the node at the end of the edge.")
+		.def("getNodeIds", &arch::Edge<T>::getNodeIds, "Returns the ids of the edge's nodes.")
+		.def("getPressure", &arch::Edge<T>::getPressure, "Returns the pressure of the edge [Pa].")
+		.def("getFlowRate", &arch::Edge<T>::getFlowRate, "Returns the flow rate within the edge [m^3/s].")
+		.def("getResistance", &arch::Edge<T>::getResistance, "Returns the inherent resistance of the edge [Pa s].");
 
-			return network.addModule(position, size, newNodes)->getId();
+	py::class_<arch::Channel<T>, arch::Edge<T>, py::smart_holder>(m, "Channel")
+		.def("setChannelType", &arch::Channel<T>::setChannelType, "Set the type of channel.")
+		.def("getChannelShape", &arch::Channel<T>::getChannelShape, "Returns the shape of the channel cross section.")
+		.def("getChannelType", &arch::Channel<T>::getChannelType, "Returns the type of the channel.")
+		.def("setLength", &arch::Channel<T>::setLength, "Set the length of the channel [m].")
+		.def("getLength", &arch::Channel<T>::getLength, "Returns the length of the channel [m].")
+		.def("getArea", &arch::Channel<T>::getArea, "Returns the area of the channel cross-section [m^2].")
+		.def("getVolume", &arch::Channel<T>::getVolume, "Returns the volume of the channel [m^3].")
+		.def("isChannelValid", &arch::Channel<T>::isChannelValid, "Returns true if the channel parameters are valid.")
+		.def("isRectangular", &arch::Channel<T>::isRectangular, "Returns true if the channel has a rectangular cross-section.")
+		.def("isCylindrical", &arch::Channel<T>::isCylindrical, "Returns true if the channel has a cylindrical cross-section.");
 
-			}, "Add a new module to the network.")
-		.def("loadNetwork", [](arch::Network<T> &network, std::string file) { 
-			porting::networkFromJSON(file, network);
-		});
+	py:class_<arch::RectangularChannel<T>, arch::Channel<T>, py::smart_holder>(m, "RectangularChannel")
+		.def("get2DFlowRate", &arch::RectangularChannel<T>::get2DFlowRate, "Maps and returns the 2-dimensional flow rate within the channel [m^2/s].")
+		.def("setWidth", &arch::RectangularChannel<T>::setWidth, "Set the width of the channel cross-section [m].")
+		.def("getWidth", &arch::RectangularChannel<T>::getWidth, "Returns the width of the channel cross-section [m].")
+		.def("setHeight", &arch::RectangularChannel<T>::setHeight, "Set the height of the channel cross-section [m].")
+		.def("getHeight", &arch::RectangularChannel<T>::getHeight, "Returns the height of the channel cross-section [m]");
 
-	py::class_<sim::Simulation<T>> baseSimulation(m, "Simulation");
-		baseSimulation.def("setNetwork", &sim::Simulation<T>::setNetwork);
-		baseSimulation.def("addFluid", [](sim::Simulation<T> &simulation, T density, T viscosity, T concentration) {
-				return simulation.addFluid(viscosity, density, concentration)->getId();
-			});
-		baseSimulation.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase));
-		baseSimulation.def("setRectangularResistanceModel", [](sim::Simulation<T> & simulation) {
-				sim::ResistanceModel1D<T>* resistanceModel = new sim::ResistanceModel1D<T>(simulation.getContinuousPhase()->getViscosity());
-				simulation.setResistanceModel(resistanceModel);
-			});
-		baseSimulation.def("setPoiseuilleResistanceModel", [](sim::Simulation<T> & simulation) {
-				sim::ResistanceModelPoiseuille<T>* resistanceModel = new sim::ResistanceModelPoiseuille<T>(simulation.getContinuousPhase()->getViscosity());
-				simulation.setResistanceModel(resistanceModel);
-			});
-		baseSimulation.def("print", &sim::Simulation<T>::printResults);
-		baseSimulation.def("saveResult", [](sim::Simulation<T> &simulation, std::string file) {
-				porting::resultToJSON(file, &simulation);
-			});
+	py:class_<arch::CylindricalChannel<T>, arch::Channel<T>, py::smart_holder>(m, "CylindricalChannel")
+		.def("setRadius", &arch::CylindricalChannel<T>::setRadius, "Set the radius of the channel cross-section [m].")
+		.def("getRadius", &arch::CylindricalChannel<T>::getRadius, "Returns the radius of the channel cross-section [m].")
 
-	py::class_<sim::AbstractContinuous<T>>(m, "AbstractContinuousSimulation", baseSimulation)
-		.def(py::init<arch::Network<T>*>())
-		.def(py::init([](std::string file, arch::Network<T>* network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::unique_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
-			}))
-		.def("simulate", &sim::AbstractContinuous<T>::simulate);
+	py::class_<arch::FlowRatePump<T>, arch::Edge<T>, py::smart_holder>(m, "FlowRatePump")
+		.def("setFlowRate", &arch::CylindricalChannel<T>::setFlowRate, "Set the flow rate of the pump [m^3/s].")
 
-	py::class_<sim::AbstractDroplet<T>>(m, "AbstractDropletSimulation", baseSimulation)
-		.def(py::init<arch::Network<T>*>())
-		.def(py::init([](std::string file, arch::Network<T>* network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::unique_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
-			}))
-		.def("addDroplet", [](sim::AbstractDroplet<T> &simulation, int fluidId, T volume) {
-				return simulation.addDroplet(fluidId, volume)->getId();
-			})
-		.def("injectDroplet", [](sim::AbstractDroplet<T> &simulation, int dropletId, T injectionTime, int channelId, T injectionPosition) {
-				simulation.addDropletInjection(dropletId, injectionTime, channelId, injectionPosition);
-			})
-		.def("simulate", &sim::AbstractDroplet<T>::simulate);
+	py::class_<arch::PressurePump<T>, arch::Edge<T>, py::smart_holder>(m, "PressurePump")
+		.def("setPressure", &arch::CylindricalChannel<T>::setPressure, "Set the pressure across the pump [Pa].")
+
+	py::class_<arch::Membrane<T>, arch::Edge<T>, py::smart_holder>(m, "Membrane")
+		.def("setDimensions", &arch::Membrane::setDimensions, "Set the dimensions of the membrane [w, h, l] [m].")
+		.def("setHeight", &arch::Membrane::setHeight, "Set the height of the membrane [m].")
+		.def("setWidth", &arch::Membrane::setWidth, "Set the width of the membrane [m].")
+		.def("setLength", &arch::Membrane::setLength, "Set the length of the membrane [m].")
+		.def("setPoreRadius", &arch::Membrane::setPoreRadius, "Set the pore radius of the pores of the membrane [m].")
+		.def("setPorosity", &arch::Membrane::setPorosity, "Set the porosity of the membrane [0.0-1.0].")
+		.def("setChannel", &arch::Membrane::setChannel, "Set the channel the membrane is connected to.")
+		.def("setTank", &arch::Membrane::setTank, "Set the tank the membrane is connected to.")
+		.def("getConcentrationChange", &arch::Membrane::getConcentrationChange, "Returns the concentration change caused by the membrane [mol].")
+		.def("getHeight", &arch::Membrane::getHeight, "Returns the height of the membrane [m].")
+		.def("getWidth", &arch::Membrane::getWidth, "Returns the width of the membrane [m].")
+		.def("getLength", &arch::Membrane::getLength, "Returns the length of the membrane [m].")
+		.def("getChannel", &arch::Membrane::getChannel, "Returns the channel that the membrane is connected to.")
+		.def("getTank", &arch::Membrane::getTank, "Returns the tank that the membrane is connected to.")
+		.def("getPoreRadius", &arch::Membrane::getPoreRadius, "Returns the pore radius of the membrane [m].")
+		.def("getPoreDiameter", &arch::Membrane::getPoreDiameter, "Returns the diameter of the pores of the membrane [m].")
+		.def("getPorosity", &arch::Membrane::getPorosity, "Returns the porosity of the membrane [0.0-1.0].")
+		.def("getNumberOfPores", &arch::Membrane::getNumberOfPores, "Returns the number of pores in a given area [m^2] of the membrane.")
+		.def("getPoreDensity", &arch::Membrane::getPoreDensity, "Returns the density of the pores in the membrane.")
+		.def("getArea", &arch::Membrane::getArea, "Returns the area of the membrane [m^2].")
+		.def("getVolume", &arch::Membrane::getVolume, "Returns the volume of the membrane [m^3].");
+
+	py::class_<arch::Tank<T>, arch::Edge<T>, py::smart_holder>(m, "Tank")
+		.def("setDimensions", &arch::Tank::setDimensions, "Set the dimensions of the tank [w, h, l] [m].")
+		.def("setHeight", &arch::Tank::setHeight, "Set the height of the tank [m].")
+		.def("setWidth", &arch::Tank::setWidth, "Set the width of the tank [m].")
+		.def("setLength", &arch::Tank::setLength, "Set the length of the tank [m].")
+		.def("getHeight", &arch::Tank::getHeight, "Returns the height of the tank [m].")
+		.def("getWidth", &arch::Tank::getWidth, "Returns the width of the tank [m].")
+		.def("getLength", &arch::Tank::getLength, "Returns the length of the tank [m].")
+		.def("getArea", &arch::Tank::getArea, "Returns the area of the tank [m^2].")
+		.def("getVolume", &arch::Tank::getVolume, "Returns the volume of the tank [m^3].");
+
+	py::class_<arch::Module<T>, py::smart_holder>(m, "Module")
+		.def("getId", &arch::Module::getId, "Returns the id of the module.")
+		.def("getPosition", &arch::Module::getPosition, "Returns the position [x, y] of the bottom left corner w.r.t. the device [m].")
+		.def("getSize", &arch::Module::getSize, "Returns the size [x, y] of the module [m].")
+		.def("getNodes", &arch::Module::getNodes, "Returns a map of nodes that are on the module's edges.")
+		.def("setModuleTypeLbm", &arch::Module::setModuleTypeLbm, "Set the type of the module to lbm simulator.")
+		.def("getModuleType", &arch::Module::getModuleType, "Returns the type of the module.");
+
+	py::class_<arch::CfdModule<T>, arch::Module<T>, py::smart_holder>(m, "CfdModule")
+		.def("assertInitialized", &arch::CfdModule::assertInitialized, "Checks whether the CFD module has valid openings and STL definitions.")
+		.def("getNetwork", &arch::CfdModule::getNetwork, "Returns a graph network that fully connects the module's boundary nodes.")
+		.def("getOpenings", &arch::CfdModule::getOpenings, "Returns a map of the openings of the module.")
+		.def("getStlFile", &arch::Module::getStlFile, "Returns the STL file that defines the CFD domain.");
+
+	py::class_<arch::Network<T>, py::smart_holder>(m, "Network")
+		.def("isNetworkValid", &arch::Network<T>::isNetworkValid, "Check if the current network is valid.")
+		.def("", &arch::Network<T>::, "")
+		.def("print", &arch::Network<T>::print, "Print the content of this network.")
+		// Nodes
+		.def("addNode", py::overload_cast<T, T, bool>(&arch::Network<T>::addNode), "Add a new node to the network.")
+		.def("getNode", &arch::Network<T>::getNode, "Returns the node with the given id.")
+		.def("getNodes", &arch::Network<T>::getNodes, "Returns all nodes in the network.")
+		.def("getGroundNodes", &arch::Network<T>::getGroundNodes, "Returns the set of nodes that are ground nodes.")
+		.def("getGroundNodeIds", &arch::Network<T>::getGroundNodeIds, "Returns the ids of the set of ground nodes.")
+		.def("getVirtualNodes", &arch::Network<T>::getVirtualNodes, "Returns the amount of virtual nodes in the network.")
+		.def("setVirtualNodes", &arch::Network<T>::setVirtualNodes, "Sets the amount of virtual nodes in the network.")
+		.def("hasNode", py::overload_cast<size_t>(&arch::Network<T>::addNode), "Returns true if the network contains the node with the given id.")
+		.def("hasNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::addNode), "Returns true if the network contains the given node.")
+		.def("setSink", py::overload_cast<size_t>(&arch::Network<T>::setSink), "Sets the node with given id to be a sink node.")
+		.def("setSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::setSink), "Sets the given node to be a sink node.")
+		.def("isSink", py::overload_cast<size_t>(&arch::Network<T>::isSink), "Returns true if the node of the given id is a sink node.")
+		.def("isSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isSink), "Returns true if the given node is a sink node.")
+		.def("setGround", py::overload_cast<size_t>(&arch::Network<T>::setGround), "Sets the node with given id to be a ground node.")
+		.def("setGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::setGround), "Sets the given node to be a ground node.")
+		.def("isGround", py::overload_cast<size_t>(&arch::Network<T>::isGround), "Returns true if the node of the given id is a ground node.")
+		.def("isGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isGround), "Returns true if the given node is a ground node.")
+		.def("calculateNodeDistance", py::overload_cast<size_t, size_t>(&arch::Network<T>::calculateNodeDistance), 
+			"Calculates the Euclidean distance between the nodes of the given ids.")
+		.def("calculateNodeDistance", py::overload_cast<std::shared_ptr<Node<T>>, std::shared_ptr<Node<T>>>(&arch::Network<T>::calculateNodeDistance), 
+			"Calculates the Euclidean distance between the two given nodes.")
+		.def("removeNode", &arch::Network<T>::removeNode, "Removes the given node from the network.")
+		// Channels
+		.def("addRectangularChannel", py::overload_cast<size_t, size_t, T, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&, T, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<size_t, size_t, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&, T, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<size_t, size_t, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("addRectangularChannel", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&, T, arch::ChannelType>(&arch::Network<T>::addRectangularChannel), 
+			"Add a new channel with rectangular cross-section to the network.")
+		.def("getChannel", &arch::Network<T>::getChannel, "Returns the channel with the given id.")
+		.def("getRectangularChannel", &arch::Network<T>::getRectangularChannel, "Returns the channel with the given id, if it is a rectangular channel.")
+		.def("getChannels", &arch::Network<T>::getChannels, "Returns all channels in the network.")
+		.def("getChannelsAtNode", py::overload_cast<size_t>(&arch::Network<T>::getChannelsAtNode), 
+				"Returns all channels in the network that are connected to the node with the given id.")
+		.def("getChannelsAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getChannelsAtNode), 
+			"Returns all channels in the network that are connected to the given node.")
+		.def("isChannel", py::overload_cast<int>(&arch::Network<T>::isChannel), "Returns true if the edge with the given id is a channel.")
+		.def("isChannel", py::overload_cast<const std::shared_ptr<arch::Edge<T>>&>(&arch::Network<T>::isChannel), "Returns true if the given edge is a channel.")
+		.def("removeChannel", &arch::Network<T>::removeChannel, "Remove the given channel from the network.")
+		// Pumps
+		.def("addFlowRatePump", &arch::Network<T>::addFlowRatePump, "Add a flow rate pump to the network.")
+		.def("getFlowRatePump", &arch::Network<T>::getFlowRatePump, "Returns the flow rate pump with the given id.")
+		.def("setFlowRatePump", &arch::Network<T>::setFlowRatePump, "Set the edge with the given id to be a flow rate pump.")
+		.def("isFlowRatePump", &arch::Network<T>::isFlowRatePump, "Returns true if the provided edge id is from a flow rate pump.")
+		.def("getFlowRatePumps", &arch::Network<T>::getFlowRatePumps, "Returns all flow rate pumps in the network.")
+		.def("removeFlowRatePump", &arch::Network<T>::removeFlowRatePump, "Removes the given flow rate pump from the network.")
+		.def("addPressurePump", &arch::Network<T>::addPressurePump, "Add a pressure pump to the network.")
+		.def("getPressurePump", &arch::Network<T>::getPressurePump, "Returns the pressure pump with the given id.")
+		.def("setPressurePump", &arch::Network<T>::setPressurePump, "Set the edge with the given id to be a pressure pump.")
+		.def("isPressurePump", &arch::Network<T>::isPressurePump, "Returns true if the provided edge id is from a pressure pump.")
+		.def("getPressurePumps", &arch::Network<T>::getPressurePumps, "Returns all pressure pumps in the network.")
+		.def("removePressurePump", &arch::Network<T>::removePressurePump, "Removes the given pressure pump from the network.")
+		// Modules
+		.def("addCfdModule", &arch::Network<T>::addCfdModule, "Adds a CFD module to the network.")
+		.def("getCfdModule", &arch::Network<T>::getCfdModule, "Returns the CFD module with the given id.")
+		.def("getCfdModules", &arch::Network<T>::getCfdModules, "Returns all CFD modules in the network.")
+		.def("removeModule", &arch::Network<T>::removeModule, "Removes the given module from the network")
+		// Membrane
+		.def("addMembraneToChannel", py::overload_cast<size_t, T, T, T, T>(&arch::Network<T>::addMembraneToChannel), "Adds a membrane to a channel in the network.")
+		.def("addMembraneToChannel", py::overload_cast<const std::shared_ptr<arch::Channel<T>>&, T, T, T, T>(&arch::Network<T>::addMembraneToChannel), 
+			"Adds a membrane to a channel in the network.")
+		.def("getMembrane", &arch::Network<T>::getMembrane, "Returns the membrane with the given id.")
+		.def("getMembraneBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getMembraneBetweenNodes), 
+			"Returns the membrane between two given nodes.")
+		.def("getMembraneBetweenNodes", py::overload_cast<const std::shared_ptr<Node<T>>&, const std::shared_ptr<Node<T>>&>(&arch::Network<T>::getMembraneBetweenNodes), 
+			"Returns the membrane between two given nodes.")
+		.def("getMembranes", &arch::Network<T>::getMembranes, "Returns all membranes in the network.")
+		.def("getMembranesAtNode", py::overload_cast<size_t>(&arch::Network<T>::getMembranesAtNode), 
+			"Returns the set of membranes that are at the given node.")
+		.def("getMembranesAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getMembranesAtNode), 
+			"Returns the set of membranes that are at the given node.")
+		.def("isMembrane", &arch::Network<T>::isMembrane, "Returns true if the given edge id belongs to a membrane.")
+		// Tank
+		.def("addTankToMembrane", py::overload_cast<size_t, T, T, T, T>(&arch::Network<T>::addTankToMembrane), "Adds a tank to a membrane in the network.")
+		.def("addTankToMembrane", py::overload_cast<const std::shared_ptr<arch::Channel<T>>&, T, T, T, T>(&arch::Network<T>::addTankToMembrane), 
+			"Adds a tank to a membrane in the network.")
+		.def("getTank", &arch::Network<T>::getTank, "Returns the tank with the given id.")
+		.def("getTankBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getTankBetweenNodes), 
+			"Returns the tank between two given nodes.")
+		.def("getTankBetweenNodes", py::overload_cast<const std::shared_ptr<Node<T>>&, const std::shared_ptr<Node<T>>&>(&arch::Network<T>::getTankBetweenNodes), 
+			"Returns the tank between two given nodes.")
+		.def("getTanks", &arch::Network<T>::getTanks, "Returns all tanks in the network.");
+		
+	m.def("createNetwork", py::overload_cast<>(&arch::Network<T>::createNetwork), "Create a Network object.");
+	m.def("createNetwork", py::overload_cast<std::unordered_map<size_t, std::shared_ptr<arch::Node<T>>>>
+		(&arch::Network<T>::createNetwork), "Create a Network object.");
+	m.def("createNetwork", py::overload_cast<std::unordered_map<size_t, std::shared_ptr<arch::Node<T>>>, 
+											std::unordered_map<size_t, std::shared_ptr<arch::Channel<T>>>>
+		(&arch::Network<T>::createNetwork), "Create a Network object.");
+	m.def("createNetwork", py::overload_cast<std::unordered_map<size_t, std::shared_ptr<arch::Node<T>>>, 
+                                            std::unordered_map<size_t, std::shared_ptr<arch::Channel<T>>>,
+                                            std::unordered_map<size_t, std::shared_ptr<arch::FlowRatePump<T>>>,
+                                            std::unordered_map<size_t, std::shared_ptr<arch::PressurePump<T>>>,
+                                            std::unordered_map<size_t, std::shared_ptr<arch::CfdModule<T>>>>
+		(&arch::Network<T>::createNetwork), "Create a Network object.");
+
+	py::class_<sim::Fluid<T>, py::smart_holder>(m, "Fluid")
+		.def("getId", &sim::Fluid<T>::getId, "Returns the id of the fluid.")
+		.def("setName", &sim::Fluid<T>::setName, "Sets the name of the fluid.")
+		.def("getName", &sim::Fluid<T>::getName, "Returns the name of the fluid.")
+		.def("setViscosity", &sim::Fluid<T>::setViscosity, "Sets the viscosity of the fluid.")
+		.def("getViscosity", &sim::Fluid<T>::getViscosity, "Returns the viscosity of the fluid.")
+		.def("setDensity", &sim::Fluid<T>::setDensity, "Sets the density of the fluid.")
+		.def("getDensity", &sim::Fluid<T>::getDensity, "Returns the density of the fluid.");
+
+	py::class_<sim::Droplet<T>, py::smart_holder>(m, "Droplet")
+		.def("getId", &sim::Droplet<T>::getId, "Returns the id of the droplet.")
+		.def("getName", &sim::Droplet<T>::getName, "Returns the name of the droplet.")
+		.def("setName", &sim::Droplet<T>::setName, "Sets the name of the droplet.")
+		.def("getVolume", &sim::Droplet<T>::getVolume, "Returns the volume of the droplet [m^3].")
+		.def("setVolume", &sim::Droplet<T>::setVolume, "Sets the volume of the droplet [m^3].")
+		.def("readFluid", &sim::Droplet<T>::readFluid, "Returns a read-only reference to the Fluid that constitutes the droplet.")
+		.def("setFluid", &sim::Droplet<T>::setFluid, "Sets the fluid that the droplet consists of.")
+		.def("readBoundaries", &sim::Droplet<T>::readBoundaries, "Returns a read-only list of the droplet boundaries.")
+		.def("readFullyOccupiedChannels", &sim::Droplet<T>::readFullyOccupiedChannels, 
+			"Returns a read-only list of the channels that the droplet occupies fully.");
+
+	py::class_<sim::Specie<T>, py::smart_holder>(m, "Specie")
+		.def("getId", &sim::Specie<T>::getId, "Returns the id of the specie.")
+		.def("setName", &sim::Specie<T>::setName, "Sets the name of the specie.")
+		.def("getName", &sim::Specie<T>::getName, "Returns the name of the specie.")
+		.def("setDiffusivity", &sim::Specie<T>::setDiffusivity, "Sets the diffusion coefficient of this species.")
+		.def("getDiffusivity", &sim::Specie<T>::getDiffusivity, "Returns the diffusion coefficient of this species.")
+		.def("setSatConc", &sim::Specie<T>::setSatConc, "Sets the saturation concentration of this specie.")
+		.def("getSatConc", &sim::Specie<T>::getSatConc, "Returns the saturation concentration of this specie.");
 	
-	py::class_<sim::HybridContinuous<T>>(m, "HybridContinuousSimulation", baseSimulation)
-		.def(py::init<arch::Network<T>*>())
-		.def(py::init([](std::string file, arch::Network<T>* network){
+	py::class_<sim::Mixture<T>, py::smart_holder>(m, "Mixture")
+		.def(py::self == py::self)
+		.def("getId", &sim::Mixture<T>::getId, "Returns the id of the mixture.")
+		.def("getName", &sim::Mixture<T>::getName, "Returns the name of the mixture.")
+		.def("setName", &sim::Mixture<T>::setName, "Sets the name of the mixture.")
+		//.def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		.def("addSpecie", &sim::Mixture<T>::addSpecie, "Adds a specie with a given concentration to this mixture.")
+		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		.def("readSpecieConcentrations", &sim::Mixture<T>::readSpecieConcentrations, "Returns a read-only map of the specie concentrations.")
+		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		.def("getConcentrationOfSpecie", &sim::Mixture<T>::getConcentrationOfSpecie, "Returns the concentration of a specie [TODO].")
+		.def("getSpecieDistributions", &sim::Mixture<T>::getSpecieDistributions, "Returns the concentration distribution of a species if it's not a constant value [TODO].")
+		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		.def("setSpecieConcentration", &sim::Mixture<T>::setSpecieConcentration, "Sets the concentration of a specie [TODO].")
+		.def("getSpecieCount", &sim::Mixture<T>::getSpecieCount, "Returns the number of species listed in the mixture.")
+		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
+		.def("removeSpecie", &sim::Mixture<T>::removeSpecie, "Removes a specie from the mixture.")
+		.def("getDensity", &sim::Mixture<T>::getDensity, "Returns the density of the mixture [kg/m^3].")
+		.def("getViscosity", &sim::Mixture<T>::getViscosity, "Returns the viscosity of the mixture [Pa s].")
+		.def("getLargestMolecularSize", &sim::Mixture<T>::getLargestMolecularSize, "Returns the largest molecular size of the species in the mixture.");
+
+	py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
+		.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
+		.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.")
+
+	py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
+		.def("getId", &sim::DropletInjection<T>getId, "Returns the id of the droplet injection.")
+		.def("getName", &sim::DropletInjection<T>getName, "Returns the name of the droplet injection.")
+		.def("setName", &sim::DropletInjection<T>setName, "Sets the name of the droplet inkection.")
+		.def("getInjectionTime", &sim::DropletInjection<T>getInjectionTime, "Returns the time at which the droplet is injected [s].")
+		.def("setInjectionTime", &sim::DropletInjection<T>setInjectionTime, "Sets the time at which the droplet should be injected [s].")
+		// Encapsulation -> Why do we set and return the ChannelPosition object, and not just channel and position parameters?
+		.def("getInjectionPosition", &sim::DropletInjection<T>getInjectionPosition, "Returns the channel and position at which the droplet is injected.")
+		.def("setInjectionPosition", &sim::DropletInjection<T>setInjectionPosition, "Sets the channel and position at which the droplet is injected.");
+
+	py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
+		.def("getId", &sim::MixtureInjection<T>getId, "Returns the id of the mixture injection.")
+		.def("getName", &sim::MixtureInjection<T>getName, "Returns the name of the mixture injection.")
+		.def("setName", &sim::MixtureInjection<T>setName, "Sets the name of the mixture inkection.")
+		.def("getInjectionTime", &sim::MixtureInjection<T>getInjectionTime, "Returns the time at which the mixture is injected [s].")
+		.def("setInjectionTime", &sim::MixtureInjection<T>setInjectionTime, "Sets the time at which the mixture should be injected [s].")
+		.def("getInjectionChannel", &sim::MixtureInjection<T>getInjectionChannel, "Returns the channel into which the mixture is injected.")
+		.def("setInjectionChannel", &sim::MixtureInjection<T>setInjectionChannel, "Sets the channel into which the mixture is injected.");
+
+	py::class_<sim::CFDSimulator<T>, py::smart_holder>(m, "CFDSimulator")
+		.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
+		.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
+		.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
+		// .def("getInitialized", &sim::CFDSimulator<T>::getInitialized, "Returns whether the simulator is initialized or not.")
+		// .def("setInitialized", &sim::CFDSimulator<T>::, "")
+		.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
+		.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
+		.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
+		.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
+		// .def("storeConcentrations", &sim::CFDSimulator<T>::, "")
+		// .def("getConcentrations", &sim::CFDSimulator<T>::, "")
+		// .def("setBoundaryValues", &sim::CFDSimulator<T>::, "")
+		.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
+		.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
+		.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
+		.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
+		.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.")
+		// .def("storeCfdResults", &sim::CFDSimulator<T>::, "");
+
+	py::class_<sim::lbmSimulator, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
+		.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
+		.def("getCharPhysVelocity", &sim::lbmSimulator<T>::getCharPhysVelocity, "Returns the characteristic physical velocity of the lbm simulator.")
+		.def("getResolution", &sim::lbmSimulator<T>::getResolution, "Returns the resolution of the lbm simulator.")
+		.def("setResolution", &sim::lbmSimulator<T>::setResolution, "Sets the resolution of the lbm simulator.")
+		.def("getEpsilon", &sim::lbmSimulator<T>::getEpsilon, "Returns the epsilon for the simulator.")
+		.def("setEpsilon", &sim::lbmSimulator<T>::setEpsilon, "Sets the epsilon for the simulator.")
+		.def("getTau", &sim::lbmSimulator<T>::getTau, "Returns the relaxation time of the simulator.")
+		.def("setTau", &sim::lbmSimulator<T>::setTau, "Sets the relaxation time of the simulator.")
+		.def("getStepIter", &sim::lbmSimulator<T>::getStepIter, "Returns the number of steps used for the value tracer (default = 1000).")
+		.def("hasConverged", &sim::lbmSimulator<T>::hasConverged, "Returns whether the simulator has converged or not.");
+
+	py::class_<sim::Simulation, py::smart_holder>(m, "Simulation")
+		.def("getPlatform", &sim::Simulation<T>::getPlatorm, "Returns the platform of the simulation.")
+		.def("getType", &sim::Simulation<T>::getType, "Returns the type of simulation [Abstract, Hybrid CFD].")
+		.def("getNetwork", &sim::Simulation<T>::getNetwork, "Returns the network on which the simulation is conducted.")
+		.def("setNetwork", &sim::Simulation<T>::setNetwork, "Sets the network on which the simulation is conducted.")
+		.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
+		.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
+		.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
+		.def("addMixedFluid", &sim::Simulation<T>::addMixedFluid, "Creates and adds a new fluid from two existing fluids.")
+		.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
+		.def("readFluids", &sim::Simulation<T>::readFluids, "Returns a read-only list of fluids.")
+		.def("removeFluid", &sim::Simulation<T>::removeFluid, "Removes a fluid from the simulation.")
+		.def("getFixtureId", &sim::Simulation<T>::getFixtureId, "Returns the fixture id.")
+		.def("setFixtureId", &sim::Simulation<T>::setFixtureId, "Sets the fixture id.")
+		.def("getContinuousPhase", &sim::Simulation<T>::getContinuousPhase, "Returns the continuous phase of the simulation.")
+		.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the fluid with the given id.")
+		.def("setContinuousPhase", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the given fluid.")
+		.def("getCurrentIteration", &sim::Simulation<T>::getCurrentIteration, "Returns the current iteration number.")
+		.def("getMaxIterations", &sim::Simulation<T>::getMaxIterations, "Returns the maximum number of allowed iterations. When reached the simulation ends.")
+		.def("setWriteInterval", &sim::Simulation<T>::setWriteInterval, "Set the iterations interval at which the stat is saved in the results.")
+		.def("getTMax", &sim::Simulation<T>::getTMax, "Returns the maximum allowed physical time. When reached the simulation ends.")
+		.def("setMaxEndTime", &sim::Simulation<T>::setMaxEndTime, "Set the maximal physical time after which the simulation ends.")
+		.def("getResults", &sim::Simulation<T>::getResults, "Returns the results of the simulation.")
+		.def("printResults", &sim::Simulation<T>::printResults, "Prints the results of the simulation to the console.")
+		.def("simulate", &sim::Simulation<T>::simulate, "Conducts the simulation.");
+
+	py::class_<sim::AbstractContinuous, sim::Simulation, py::smart_holder>(m, "AbstractContinuous")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
 				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::unique_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
+				return std::shared_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
+			}));
+
+	py::class_<sim::AbstractDroplet, sim::Simulation, py::smart_holder>(m, "AbstractDroplet")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
 			}))
-		.def("simulate", &sim::HybridContinuous<T>::simulate)
-		.def("addLbmSimulator", [](	sim::HybridContinuous<T> &simulation, 
-									std::string name,
-									std::string stlFile,
-									int moduleId,
-									std::vector<int> nodes,
-									std::vector<std::vector<T>> normals,
-									std::vector<T> widths,
-									T charPhysLength,
-									T charPhysVelocity,
-									T resolution,
-									T epsilon,
-									T tau) {
+		.def("addDroplet", py::overload_cast<int, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet of the given fluid id to the simulation.")
+		.def("addDroplet", py::overload_cast<const std::shared_ptr<Fluid<T>>&, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet to the simulation.")
+		.def("addMergedDroplet", py::overload_cast<int, int>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+			"Adds a droplet to the simulator, based on the ids of two existing droplets.")
+		.def("addMergedDroplet", py::overload_cast<const std::shared_ptr<Droplet<T>>&, const std::shared_ptr<Droplet<T>>&>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+			"Adds a droplet to the simulator, based on two existing droplets.")
+		.def("getDroplet", &sim::AbstractDroplet<T>::getDroplet, "Returns the droplet with the given id.")
+		.def("getDropletAtNode", py::overload_cast<int>(&sim::AbstractDroplet<T>::getDropletAtNode), 
+			"Checks whether a droplet is present at the node with the given id. Returns true and the droplet if one is found.")
+		.def("getDropletAtNode", py::overload_cast<const std::shared_ptr<arch::Node<T>>&>(&sim::AbstractDroplet<T>::getDropletAtNode), 
+			"Checks whether a droplet is present at the given node. Returns true and the droplet if one is found.")
+		.def("removeDroplet", &sim::AbstractDroplet<T>::removeDroplet, "Removes a droplet from the simulation.")
+		.def("addDropletInjection", py::overload_cast<int, T, int, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+		.def("addDropletInjection", py::overload_cast<const std::shared_ptr<Droplet<T>>&, T, const std::shared_ptr<arch::Channel<T>>&, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+		.def("getDropletInjection", &sim::AbstractDroplet<T>::getDropletInjection, "Returns the droplet injection with the given id.")
+		.def("removeDropletInjection", &sim::AbstractDroplet<T>::removeDropletInjection, "Removes the droplet injection from the simulation.");
 
-			std::unordered_map<int, arch::Opening<T>> openings;
+	py::class_<sim::AbstractMembrane, sim::Simulation, py::smart_holder>(m, "AbstractMembrane")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
+			}))
+		.def("setPermeabilityMembraneModel", &sim::AbstractMembrane<T>::setPermeabilityMembraneModel, "Sets the permeability membrane model.")
+		.def("setPoreResistanceMembraneModel", &sim::AbstractMembrane<T>::setPoreResistanceMembraneModel, "Sets the pore resistance membrane model.")
+		.def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
+		.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
+		.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
+		.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")
+		.def("setMembraneModel4", &sim::AbstractMembrane<T>::setMembraneModel4, "Sets membrane model 4.")
+		.def("setMembraneModel5", &sim::AbstractMembrane<T>::setMembraneModel5, "Sets membrane model 5.")
+		.def("setMembraneModel6", &sim::AbstractMembrane<T>::setMembraneModel6, "Sets membrane model 6.")
+		.def("setMembraneModel7", &sim::AbstractMembrane<T>::setMembraneModel7, "Sets membrane model 7.")
+		.def("setMembraneModel8", &sim::AbstractMembrane<T>::setMembraneModel8, "Sets membrane model 8.")
+		.def("setMembraneModel9", &sim::AbstractMembrane<T>::setMembraneModel9, "Sets membrane model 9.")
+		.def("getMembraneResistance", &sim::AbstractMembrane<T>::getMembraneResistance, "Returns the membrane resistance.")
 
-			// ASSERT equal length for nodes, normals, widths and heights
-			if (nodes.size() != normals.size() || nodes.size() != widths.size()) {
-				throw std::invalid_argument("There should be an equal amount of nodes, normals, and widths");
-			}
+	py::class_<sim::AbstractMixing, sim::Simulation, py::smart_holder>(m, "AbstractMixing")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractMixing<T>>(dynamic_cast<sim::AbstractMixing<T>*>(tmpPtr.release()));
+			}))
+		.def("setInstantaneousMixingModel", &sim::AbstractMixing<T>::setInstantaneousMixingModel, "Sets the instantaneous mixing model.")
+		.def("hasInstantaneousMixingModel", &sim::AbstractMixing<T>::hasInstantaneousMixingModel, "Returns whether an instantaneous mixing model was set.")
+		.def("setDiffusiveMixingModel", &sim::AbstractMixing<T>::setDiffusiveMixingModel, "Sets the diffusive mixing model.")
+		.def("hasDiffusiveMixingModel", &sim::AbstractMixing<T>::hasDiffusiveMixingModel, "Returns whether a diffusive mixing model was set.")
+		.def("addSpecie", &sim::AbstractMixing<T>::addSpecie, "Adds a single species to the simulator.")
+		.def("getSpecie", &sim::AbstractMixing<T>::getSpecie, "Returns a species with the given id.")
+		.def("removeSpecie", &sim::AbstractMixing<T>::removeSpecies, "Removes a species from the simulator.")
+		.def("addMixture", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+		.def("addMixture", py::overload_cast<const std::vector<std::shared_ptr<sim::Specie<T>>>&, const std::vector<T>&>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+		.def("getMixture", &sim::AbstractMixing<T>::getMixture, "Returns the mixture with the given id.")
+		.def("readMixtures", &sim::AbstractMixing<T>::readMixtures, "Returns a read-only list of mixtures in the simulator.")
+		.def("removeMixture", &sim::AbstractMixing<T>::removeMixture, "Removes a mixture from the simulator.")
+		.def("addMixtureInjection", py::overload_cast<int, int, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixtureId"), py::arg("edgeId"), py::arg("injectionTime"), py::arg("isPermanent")=false, 
+			"Add a mixture injection to the simulator.")
+		.def("addMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixture"), py::arg("edge"), 
+			py::arg("injectionTime"), py::arg("isPermanent")=false, "Add a mixture injection to the simulator")
+		.def("addPermanentMixtureInjection", py::overload_cast<int, int, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), "Add a permanent mixture injection to the simulator.")
+		.def("addPermanentMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), 
+			"Add a permanent mixture injection to the simulator.")
+		.def("getMixtureInjection", &sim::AbstractMixing<T>::getMixtureInjection, "Returns the mixture injection with the given id.")
+		.def("removeMixtureInjection", &sim::AbstractMixing<T>::removeMixtureInjection, "Removes the mixture injection with the given id.");
 
-			// ASSERT equal length for nodes, normals, widths and heights
-			if (nodes.size() != simulation.getNetwork()->getModule(moduleId)->getNodes().size()) {
-				throw std::invalid_argument("There should be an equal amount of nodes passed as in the provided module.");
-			}
-
-			for (long unsigned int i=0; i<nodes.size(); ++i) {
-				openings.try_emplace(nodes[i], arch::Opening<T>{simulation.getNetwork()->getNode(nodes[i]), normals[i], widths[i]});
-			}
-			
-			return simulation.addLbmSimulator(	name, stlFile, simulation.getNetwork()->getModule(moduleId), openings, charPhysLength,
-												charPhysVelocity, resolution, epsilon, tau)->getId();
-
-			}, "Add a LBM simulator to the simulation.");
-
+	py::class_<sim::HybridContinuous, sim::Simulation, py::smart_holder>(m, "HybridContinuous")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
+			}))
+		.def("getCharacteristicLength", &sim::HybridContinuous<T>::getCharacteristicLength, "Returns the characteristic length of the LBM simulators.")
+		.def("getCharacteristicVelocity", &sim::HybridContinuous<T>::getCharacteristicVelocity, "Returns the characteristic velocity of the LBM simulators.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("resolution"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, T, T, T, T, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("resolution"), py::arg("epsilon"), py::arg("tau"), py::arg("charPhysLength"), py::arg("charPhysVelocity"), py::arg("name")="", 
+			"Add a LBM simulator to the hybrid simulation.")
+		.def("getLbmSimulator", &sim::HybridContinuous<T>::getLbmSimulator, "Returns the LBM simulator with the given id.")
+		.def("removeLbmSimulator", &sim::HybridContinuous<T>::removeLbmSimulator, "Removes the LBM simulator from the hybrid simulation.")
+		.def("setNaiveHybridScheme", py::overload_cast<T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), "Set the naive update scheme for all simulators.")
+		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+			"Set the naive update scheme for the given simulator.")
+		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, std::unordered_map<int, T>, std::unordered_map<int, T>, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+			"Set the naive update scheme for the given simulator.")
+		.def("getGlobalPressureBounds", &sim::HybridContinuous<T>::getGlobalPressureBounds, "Returns the global pressure bounds in the CFD simulators.")
+		.def("getGlobalVelocityBounds", &sim::HybridContinuous<T>::getGlobalVelocityBounds, "Returns the global velocity bounds in the CFD simulators.")
+		.def("writePressurePpm", &sim::HybridContinuous<T>::writePressurePpm, "Write the pressure field in ppm format for all simulators.")
+		.def("writeVelocityPpm", &sim::HybridContinuous<T>::writeVelocityPpm, "Write the velocity field in ppm format for all simulators.");
+		
 	#ifdef VERSION_INFO
 	m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 	#else

--- a/python/mmft/simulator/bindings.cpp
+++ b/python/mmft/simulator/bindings.cpp
@@ -105,6 +105,7 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getWidth", &arch::Membrane<T>::getWidth, "Returns the width of the membrane [m].")
 		.def("getLength", &arch::Membrane<T>::getLength, "Returns the length of the membrane [m].")
 		.def("getChannel", &arch::Membrane<T>::getChannel, "Returns the channel that the membrane is connected to.")
+		.def("getRectangularChannel", &arch::Membrane<T>::getRectangularChannel, "Returns the rectangular channel that the membrane is connected to.")
 		.def("getTank", &arch::Membrane<T>::getTank, "Returns the tank that the membrane is connected to.")
 		.def("getPoreRadius", &arch::Membrane<T>::getPoreRadius, "Returns the pore radius of the membrane [m].")
 		.def("getPoreDiameter", &arch::Membrane<T>::getPoreDiameter, "Returns the diameter of the pores of the membrane [m].")
@@ -304,193 +305,200 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getViscosity", &sim::Mixture<T>::getViscosity, "Returns the viscosity of the mixture [Pa s].")
 		.def("getLargestMolecularSize", &sim::Mixture<T>::getLargestMolecularSize, "Returns the largest molecular size of the species in the mixture.");
 
-	// py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
-	// 	.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
-	// 	.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.");
+	py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
+		.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
+		.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.");
 
-	// py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
-	// 	.def("getId", &sim::DropletInjection<T>getId, "Returns the id of the droplet injection.")
-	// 	.def("getName", &sim::DropletInjection<T>getName, "Returns the name of the droplet injection.")
-	// 	.def("setName", &sim::DropletInjection<T>setName, "Sets the name of the droplet inkection.")
-	// 	.def("getInjectionTime", &sim::DropletInjection<T>getInjectionTime, "Returns the time at which the droplet is injected [s].")
-	// 	.def("setInjectionTime", &sim::DropletInjection<T>setInjectionTime, "Sets the time at which the droplet should be injected [s].")
-	// 	// Encapsulation -> Why do we set and return the ChannelPosition object, and not just channel and position parameters?
-	// 	.def("getInjectionPosition", &sim::DropletInjection<T>getInjectionPosition, "Returns the channel and position at which the droplet is injected.")
-	// 	.def("setInjectionPosition", &sim::DropletInjection<T>setInjectionPosition, "Sets the channel and position at which the droplet is injected.");
+	py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
+		.def("getId", &sim::DropletInjection<T>::getId, "Returns the id of the droplet injection.")
+		.def("getName", &sim::DropletInjection<T>::getName, "Returns the name of the droplet injection.")
+		.def("setName", &sim::DropletInjection<T>::setName, "Sets the name of the droplet inkection.")
+		.def("getInjectionTime", &sim::DropletInjection<T>::getInjectionTime, "Returns the time at which the droplet is injected [s].")
+		.def("setInjectionTime", &sim::DropletInjection<T>::setInjectionTime, "Sets the time at which the droplet should be injected [s].")
+		// Encapsulation -> Why do we set and return the ChannelPosition object, and not just channel and position parameters?
+		.def("getInjectionPosition", &sim::DropletInjection<T>::getInjectionPosition, "Returns the channel and position at which the droplet is injected.")
+		.def("setInjectionPosition", &sim::DropletInjection<T>::setInjectionPosition, "Sets the channel and position at which the droplet is injected.");
 
-	// py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
-	// 	.def("getId", &sim::MixtureInjection<T>getId, "Returns the id of the mixture injection.")
-	// 	.def("getName", &sim::MixtureInjection<T>getName, "Returns the name of the mixture injection.")
-	// 	.def("setName", &sim::MixtureInjection<T>setName, "Sets the name of the mixture inkection.")
-	// 	.def("getInjectionTime", &sim::MixtureInjection<T>getInjectionTime, "Returns the time at which the mixture is injected [s].")
-	// 	.def("setInjectionTime", &sim::MixtureInjection<T>setInjectionTime, "Sets the time at which the mixture should be injected [s].")
-	// 	.def("getInjectionChannel", &sim::MixtureInjection<T>getInjectionChannel, "Returns the channel into which the mixture is injected.")
-	// 	.def("setInjectionChannel", &sim::MixtureInjection<T>setInjectionChannel, "Sets the channel into which the mixture is injected.");
+	py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
+		.def("getId", &sim::MixtureInjection<T>::getId, "Returns the id of the mixture injection.")
+		.def("getName", &sim::MixtureInjection<T>::getName, "Returns the name of the mixture injection.")
+		.def("setName", &sim::MixtureInjection<T>::setName, "Sets the name of the mixture inkection.")
+		.def("getInjectionTime", &sim::MixtureInjection<T>::getInjectionTime, "Returns the time at which the mixture is injected [s].")
+		.def("setInjectionTime", &sim::MixtureInjection<T>::setInjectionTime, "Sets the time at which the mixture should be injected [s].")
+		.def("getInjectionChannel", &sim::MixtureInjection<T>::getInjectionChannel, "Returns the channel into which the mixture is injected.")
+		.def("setInjectionChannel", &sim::MixtureInjection<T>::setInjectionChannel, "Sets the channel into which the mixture is injected.");
 
-	// py::class_<sim::CFDSimulator<T>, py::smart_holder>(m, "CFDSimulator")
-	// 	.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
-	// 	.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
-	// 	.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
-	// 	// .def("getInitialized", &sim::CFDSimulator<T>::getInitialized, "Returns whether the simulator is initialized or not.")
-	// 	// .def("setInitialized", &sim::CFDSimulator<T>::, "")
-	// 	.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
-	// 	.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
-	// 	.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
-	// 	.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
-	// 	// .def("storeConcentrations", &sim::CFDSimulator<T>::, "")
-	// 	// .def("getConcentrations", &sim::CFDSimulator<T>::, "")
-	// 	// .def("setBoundaryValues", &sim::CFDSimulator<T>::, "")
-	// 	.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
-	// 	.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
-	// 	.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
-	// 	.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
-	// 	.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.")
-	// 	// .def("storeCfdResults", &sim::CFDSimulator<T>::, "");
+	py::class_<sim::CFDSimulator<T>, py::smart_holder>(m, "CFDSimulator")
+		.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
+		.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
+		.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
+		// .def("getInitialized", &sim::CFDSimulator<T>::getInitialized, "Returns whether the simulator is initialized or not.")
+		// .def("setInitialized", &sim::CFDSimulator<T>::, "")
+		.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
+		.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
+		.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
+		.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
+		// .def("storeConcentrations", &sim::CFDSimulator<T>::, "")
+		// .def("getConcentrations", &sim::CFDSimulator<T>::, "")
+		// .def("setBoundaryValues", &sim::CFDSimulator<T>::, "")
+		.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
+		.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
+		.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
+		.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
+		.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.");
+		// .def("storeCfdResults", &sim::CFDSimulator<T>::, "");
 
-	// py::class_<sim::lbmSimulator, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
-	// 	.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
-	// 	.def("getCharPhysVelocity", &sim::lbmSimulator<T>::getCharPhysVelocity, "Returns the characteristic physical velocity of the lbm simulator.")
-	// 	.def("getResolution", &sim::lbmSimulator<T>::getResolution, "Returns the resolution of the lbm simulator.")
-	// 	.def("setResolution", &sim::lbmSimulator<T>::setResolution, "Sets the resolution of the lbm simulator.")
-	// 	.def("getEpsilon", &sim::lbmSimulator<T>::getEpsilon, "Returns the epsilon for the simulator.")
-	// 	.def("setEpsilon", &sim::lbmSimulator<T>::setEpsilon, "Sets the epsilon for the simulator.")
-	// 	.def("getTau", &sim::lbmSimulator<T>::getTau, "Returns the relaxation time of the simulator.")
-	// 	.def("setTau", &sim::lbmSimulator<T>::setTau, "Sets the relaxation time of the simulator.")
-	// 	.def("getStepIter", &sim::lbmSimulator<T>::getStepIter, "Returns the number of steps used for the value tracer (default = 1000).")
-	// 	.def("hasConverged", &sim::lbmSimulator<T>::hasConverged, "Returns whether the simulator has converged or not.");
+	py::class_<sim::lbmSimulator<T>, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
+		.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
+		.def("getCharPhysVelocity", &sim::lbmSimulator<T>::getCharPhysVelocity, "Returns the characteristic physical velocity of the lbm simulator.")
+		.def("getResolution", &sim::lbmSimulator<T>::getResolution, "Returns the resolution of the lbm simulator.")
+		.def("setResolution", &sim::lbmSimulator<T>::setResolution, "Sets the resolution of the lbm simulator.")
+		.def("getEpsilon", &sim::lbmSimulator<T>::getEpsilon, "Returns the epsilon for the simulator.")
+		.def("setEpsilon", &sim::lbmSimulator<T>::setEpsilon, "Sets the epsilon for the simulator.")
+		.def("getTau", &sim::lbmSimulator<T>::getTau, "Returns the relaxation time of the simulator.")
+		.def("setTau", &sim::lbmSimulator<T>::setTau, "Sets the relaxation time of the simulator.")
+		.def("getStepIter", &sim::lbmSimulator<T>::getStepIter, "Returns the number of steps used for the value tracer (default = 1000).")
+		.def("hasConverged", &sim::lbmSimulator<T>::hasConverged, "Returns whether the simulator has converged or not.");
 
-	// py::class_<sim::Simulation, py::smart_holder>(m, "Simulation")
-	// 	.def("getPlatform", &sim::Simulation<T>::getPlatorm, "Returns the platform of the simulation.")
-	// 	.def("getType", &sim::Simulation<T>::getType, "Returns the type of simulation [Abstract, Hybrid CFD].")
-	// 	.def("getNetwork", &sim::Simulation<T>::getNetwork, "Returns the network on which the simulation is conducted.")
-	// 	.def("setNetwork", &sim::Simulation<T>::setNetwork, "Sets the network on which the simulation is conducted.")
-	// 	.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
-	// 	.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
-	// 	.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
-	// 	.def("addMixedFluid", &sim::Simulation<T>::addMixedFluid, "Creates and adds a new fluid from two existing fluids.")
-	// 	.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
-	// 	.def("readFluids", &sim::Simulation<T>::readFluids, "Returns a read-only list of fluids.")
-	// 	.def("removeFluid", &sim::Simulation<T>::removeFluid, "Removes a fluid from the simulation.")
-	// 	.def("getFixtureId", &sim::Simulation<T>::getFixtureId, "Returns the fixture id.")
-	// 	.def("setFixtureId", &sim::Simulation<T>::setFixtureId, "Sets the fixture id.")
-	// 	.def("getContinuousPhase", &sim::Simulation<T>::getContinuousPhase, "Returns the continuous phase of the simulation.")
-	// 	.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the fluid with the given id.")
-	// 	.def("setContinuousPhase", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the given fluid.")
-	// 	.def("getCurrentIteration", &sim::Simulation<T>::getCurrentIteration, "Returns the current iteration number.")
-	// 	.def("getMaxIterations", &sim::Simulation<T>::getMaxIterations, "Returns the maximum number of allowed iterations. When reached the simulation ends.")
-	// 	.def("setWriteInterval", &sim::Simulation<T>::setWriteInterval, "Set the iterations interval at which the stat is saved in the results.")
-	// 	.def("getTMax", &sim::Simulation<T>::getTMax, "Returns the maximum allowed physical time. When reached the simulation ends.")
-	// 	.def("setMaxEndTime", &sim::Simulation<T>::setMaxEndTime, "Set the maximal physical time after which the simulation ends.")
-	// 	.def("getResults", &sim::Simulation<T>::getResults, "Returns the results of the simulation.")
-	// 	.def("printResults", &sim::Simulation<T>::printResults, "Prints the results of the simulation to the console.")
-	// 	.def("simulate", &sim::Simulation<T>::simulate, "Conducts the simulation.");
+	py::class_<sim::Simulation<T>, py::smart_holder>(m, "Simulation")
+		.def("getPlatform", &sim::Simulation<T>::getPlatform, "Returns the platform of the simulation.")
+		.def("getType", &sim::Simulation<T>::getType, "Returns the type of simulation [Abstract, Hybrid CFD].")
+		.def("getNetwork", &sim::Simulation<T>::getNetwork, "Returns the network on which the simulation is conducted.")
+		.def("setNetwork", &sim::Simulation<T>::setNetwork, "Sets the network on which the simulation is conducted.")
+		.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
+		.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
+		.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
+		// .def("addMixedFluid", py::overload_cast<int, T, int, T>(&sim::Simulation<T>::addMixedFluid), 
+			// "Creates and adds a new fluid from two existing fluids.")
+		.def("addMixedFluid", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&, T, const std::shared_ptr<sim::Fluid<T>>&, T>(&sim::Simulation<T>::addMixedFluid), 
+			"Creates and adds a new fluid from two existing fluids.")
+		.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
+		.def("readFluids", &sim::Simulation<T>::readFluids, py::return_value_policy::reference, "Returns a read-only list of fluids.")
+		.def("removeFluid", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::removeFluid), 
+			"Removes a fluid from the simulation.")
+		.def("getFixtureId", &sim::Simulation<T>::getFixtureId, "Returns the fixture id.")
+		.def("setFixtureId", &sim::Simulation<T>::setFixtureId, "Sets the fixture id.")
+		.def("getContinuousPhase", &sim::Simulation<T>::getContinuousPhase, "Returns the continuous phase of the simulation.")
+		.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the fluid with the given id.")
+		.def("setContinuousPhase", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the given fluid.")
+		.def("getCurrentIteration", &sim::Simulation<T>::getCurrentIteration, "Returns the current iteration number.")
+		.def("getMaxIterations", &sim::Simulation<T>::getMaxIterations, "Returns the maximum number of allowed iterations. When reached the simulation ends.")
+		.def("setWriteInterval", &sim::Simulation<T>::setWriteInterval, "Set the iterations interval at which the stat is saved in the results.")
+		.def("getTMax", &sim::Simulation<T>::getTMax, "Returns the maximum allowed physical time. When reached the simulation ends.")
+		.def("setMaxEndTime", &sim::Simulation<T>::setMaxEndTime, "Set the maximal physical time after which the simulation ends.")
+		// TODO today
+		// .def("getResults", &sim::Simulation<T>::getResults, py::return_value_policy::reference, "Returns the results of the simulation.")
+		.def("printResults", &sim::Simulation<T>::printResults, "Prints the results of the simulation to the console.")
+		.def("simulate", &sim::Simulation<T>::simulate, "Conducts the simulation.");
 
-	// py::class_<sim::AbstractContinuous, sim::Simulation, py::smart_holder>(m, "AbstractContinuous")
-	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
-	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-	// 			return std::shared_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
-	// 		}));
+	py::class_<sim::AbstractContinuous<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractContinuous")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
+			}));
 
-	// py::class_<sim::AbstractDroplet, sim::Simulation, py::smart_holder>(m, "AbstractDroplet")
-	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
-	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-	// 			return std::shared_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
-	// 		}))
-	// 	.def("addDroplet", py::overload_cast<int, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet of the given fluid id to the simulation.")
-	// 	.def("addDroplet", py::overload_cast<const std::shared_ptr<Fluid<T>>&, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet to the simulation.")
-	// 	.def("addMergedDroplet", py::overload_cast<int, int>(&sim::AbstractDroplet<T>::addMergedDroplet), 
-	// 		"Adds a droplet to the simulator, based on the ids of two existing droplets.")
-	// 	.def("addMergedDroplet", py::overload_cast<const std::shared_ptr<Droplet<T>>&, const std::shared_ptr<Droplet<T>>&>(&sim::AbstractDroplet<T>::addMergedDroplet), 
-	// 		"Adds a droplet to the simulator, based on two existing droplets.")
-	// 	.def("getDroplet", &sim::AbstractDroplet<T>::getDroplet, "Returns the droplet with the given id.")
-	// 	.def("getDropletAtNode", py::overload_cast<int>(&sim::AbstractDroplet<T>::getDropletAtNode), 
-	// 		"Checks whether a droplet is present at the node with the given id. Returns true and the droplet if one is found.")
-	// 	.def("getDropletAtNode", py::overload_cast<const std::shared_ptr<arch::Node<T>>&>(&sim::AbstractDroplet<T>::getDropletAtNode), 
-	// 		"Checks whether a droplet is present at the given node. Returns true and the droplet if one is found.")
-	// 	.def("removeDroplet", &sim::AbstractDroplet<T>::removeDroplet, "Removes a droplet from the simulation.")
-	// 	.def("addDropletInjection", py::overload_cast<int, T, int, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
-	// 		"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
-	// 	.def("addDropletInjection", py::overload_cast<const std::shared_ptr<Droplet<T>>&, T, const std::shared_ptr<arch::Channel<T>>&, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
-	// 		"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
-	// 	.def("getDropletInjection", &sim::AbstractDroplet<T>::getDropletInjection, "Returns the droplet injection with the given id.")
-	// 	.def("removeDropletInjection", &sim::AbstractDroplet<T>::removeDropletInjection, "Removes the droplet injection from the simulation.");
+	py::class_<sim::AbstractDroplet<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractDroplet")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
+			}))
+		.def("addDroplet", py::overload_cast<int, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet of the given fluid id to the simulation.")
+		.def("addDroplet", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet to the simulation.")
+		.def("addMergedDroplet", py::overload_cast<int, int>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+			"Adds a droplet to the simulator, based on the ids of two existing droplets.")
+		.def("addMergedDroplet", py::overload_cast<const std::shared_ptr<sim::Droplet<T>>&, const std::shared_ptr<sim::Droplet<T>>&>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+			"Adds a droplet to the simulator, based on two existing droplets.")
+		.def("getDroplet", &sim::AbstractDroplet<T>::getDroplet, "Returns the droplet with the given id.")
+		.def("getDropletAtNode", py::overload_cast<int>(&sim::AbstractDroplet<T>::getDropletAtNode, py::const_), 
+			"Checks whether a droplet is present at the node with the given id. Returns true and the droplet if one is found.")
+		.def("getDropletAtNode", py::overload_cast<const std::shared_ptr<arch::Node<T>>&>(&sim::AbstractDroplet<T>::getDropletAtNode, py::const_), 
+			"Checks whether a droplet is present at the given node. Returns true and the droplet if one is found.")
+		.def("removeDroplet", py::overload_cast<const std::shared_ptr<sim::Droplet<T>>&>(&sim::AbstractDroplet<T>::removeDroplet), "Removes a droplet from the simulation.")
+		.def("addDropletInjection", py::overload_cast<int, T, int, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+		.def("addDropletInjection", py::overload_cast<const std::shared_ptr<sim::Droplet<T>>&, T, const std::shared_ptr<arch::Channel<T>>&, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+		.def("getDropletInjection", &sim::AbstractDroplet<T>::getDropletInjection, "Returns the droplet injection with the given id.")
+		.def("removeDropletInjection", py::overload_cast<const std::shared_ptr<sim::DropletInjection<T>>&>(&sim::AbstractDroplet<T>::removeDropletInjection), 
+			"Removes the droplet injection from the simulation.");
 
-	// py::class_<sim::AbstractMembrane, sim::Simulation, py::smart_holder>(m, "AbstractMembrane")
-	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
-	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-	// 			return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
-	// 		}))
-	// 	.def("setPermeabilityMembraneModel", &sim::AbstractMembrane<T>::setPermeabilityMembraneModel, "Sets the permeability membrane model.")
-	// 	.def("setPoreResistanceMembraneModel", &sim::AbstractMembrane<T>::setPoreResistanceMembraneModel, "Sets the pore resistance membrane model.")
-	// 	.def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
-	// 	.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
-	// 	.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
-	// 	.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")
-	// 	.def("setMembraneModel4", &sim::AbstractMembrane<T>::setMembraneModel4, "Sets membrane model 4.")
-	// 	.def("setMembraneModel5", &sim::AbstractMembrane<T>::setMembraneModel5, "Sets membrane model 5.")
-	// 	.def("setMembraneModel6", &sim::AbstractMembrane<T>::setMembraneModel6, "Sets membrane model 6.")
-	// 	.def("setMembraneModel7", &sim::AbstractMembrane<T>::setMembraneModel7, "Sets membrane model 7.")
-	// 	.def("setMembraneModel8", &sim::AbstractMembrane<T>::setMembraneModel8, "Sets membrane model 8.")
-	// 	.def("setMembraneModel9", &sim::AbstractMembrane<T>::setMembraneModel9, "Sets membrane model 9.")
-	// 	.def("getMembraneResistance", &sim::AbstractMembrane<T>::getMembraneResistance, "Returns the membrane resistance.")
+	py::class_<sim::AbstractMembrane<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractMembrane")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
+			}))
+		// .def("setPermeabilityMembraneModel", &sim::AbstractMembrane<T>::setPermeabilityMembraneModel, "Sets the permeability membrane model.")
+		// .def("setPoreResistanceMembraneModel", &sim::AbstractMembrane<T>::setPoreResistanceMembraneModel, "Sets the pore resistance membrane model.")
+		// .def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
+		.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
+		.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
+		.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")
+		.def("setMembraneModel4", &sim::AbstractMembrane<T>::setMembraneModel4, "Sets membrane model 4.")
+		.def("setMembraneModel5", &sim::AbstractMembrane<T>::setMembraneModel5, "Sets membrane model 5.")
+		.def("setMembraneModel6", &sim::AbstractMembrane<T>::setMembraneModel6, "Sets membrane model 6.")
+		.def("setMembraneModel7", &sim::AbstractMembrane<T>::setMembraneModel7, "Sets membrane model 7.")
+		.def("setMembraneModel8", &sim::AbstractMembrane<T>::setMembraneModel8, "Sets membrane model 8.")
+		.def("setMembraneModel9", &sim::AbstractMembrane<T>::setMembraneModel9, "Sets membrane model 9.")
+		.def("getMembraneResistance", &sim::AbstractMembrane<T>::getMembraneResistance, "Returns the membrane resistance.");
 
-	// py::class_<sim::AbstractMixing, sim::Simulation, py::smart_holder>(m, "AbstractMixing")
-	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
-	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-	// 			return std::shared_ptr<sim::AbstractMixing<T>>(dynamic_cast<sim::AbstractMixing<T>*>(tmpPtr.release()));
-	// 		}))
-	// 	.def("setInstantaneousMixingModel", &sim::AbstractMixing<T>::setInstantaneousMixingModel, "Sets the instantaneous mixing model.")
-	// 	.def("hasInstantaneousMixingModel", &sim::AbstractMixing<T>::hasInstantaneousMixingModel, "Returns whether an instantaneous mixing model was set.")
-	// 	.def("setDiffusiveMixingModel", &sim::AbstractMixing<T>::setDiffusiveMixingModel, "Sets the diffusive mixing model.")
-	// 	.def("hasDiffusiveMixingModel", &sim::AbstractMixing<T>::hasDiffusiveMixingModel, "Returns whether a diffusive mixing model was set.")
-	// 	.def("addSpecie", &sim::AbstractMixing<T>::addSpecie, "Adds a single species to the simulator.")
-	// 	.def("getSpecie", &sim::AbstractMixing<T>::getSpecie, "Returns a species with the given id.")
-	// 	.def("removeSpecie", &sim::AbstractMixing<T>::removeSpecies, "Removes a species from the simulator.")
-	// 	.def("addMixture", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
-	// 	.def("addMixture", py::overload_cast<const std::vector<std::shared_ptr<sim::Specie<T>>>&, const std::vector<T>&>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
-	// 	.def("getMixture", &sim::AbstractMixing<T>::getMixture, "Returns the mixture with the given id.")
-	// 	.def("readMixtures", &sim::AbstractMixing<T>::readMixtures, "Returns a read-only list of mixtures in the simulator.")
-	// 	.def("removeMixture", &sim::AbstractMixing<T>::removeMixture, "Removes a mixture from the simulator.")
-	// 	.def("addMixtureInjection", py::overload_cast<int, int, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixtureId"), py::arg("edgeId"), py::arg("injectionTime"), py::arg("isPermanent")=false, 
-	// 		"Add a mixture injection to the simulator.")
-	// 	.def("addMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixture"), py::arg("edge"), 
-	// 		py::arg("injectionTime"), py::arg("isPermanent")=false, "Add a mixture injection to the simulator")
-	// 	.def("addPermanentMixtureInjection", py::overload_cast<int, int, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), "Add a permanent mixture injection to the simulator.")
-	// 	.def("addPermanentMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), 
-	// 		"Add a permanent mixture injection to the simulator.")
-	// 	.def("getMixtureInjection", &sim::AbstractMixing<T>::getMixtureInjection, "Returns the mixture injection with the given id.")
-	// 	.def("removeMixtureInjection", &sim::AbstractMixing<T>::removeMixtureInjection, "Removes the mixture injection with the given id.");
+	py::class_<sim::AbstractMixing<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractMixing")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractMixing<T>>(dynamic_cast<sim::AbstractMixing<T>*>(tmpPtr.release()));
+			}))
+		.def("setInstantaneousMixingModel", &sim::AbstractMixing<T>::setInstantaneousMixingModel, "Sets the instantaneous mixing model.")
+		.def("hasInstantaneousMixingModel", &sim::AbstractMixing<T>::hasInstantaneousMixingModel, "Returns whether an instantaneous mixing model was set.")
+		.def("setDiffusiveMixingModel", &sim::AbstractMixing<T>::setDiffusiveMixingModel, "Sets the diffusive mixing model.")
+		.def("hasDiffusiveMixingModel", &sim::AbstractMixing<T>::hasDiffusiveMixingModel, "Returns whether a diffusive mixing model was set.")
+		.def("addSpecie", &sim::AbstractMixing<T>::addSpecie, "Adds a single species to the simulator.")
+		.def("getSpecie", &sim::AbstractMixing<T>::getSpecie, "Returns a species with the given id.")
+		.def("removeSpecie", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::AbstractMixing<T>::removeSpecie), "Removes a species from the simulator.")
+		.def("addMixture", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+		.def("addMixture", py::overload_cast<const std::vector<std::shared_ptr<sim::Specie<T>>>&, const std::vector<T>&>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+		.def("getMixture", &sim::AbstractMixing<T>::getMixture, "Returns the mixture with the given id.")
+		.def("readMixtures", &sim::AbstractMixing<T>::readMixtures, "Returns a read-only list of mixtures in the simulator.")
+		.def("removeMixture", py::overload_cast<const std::shared_ptr<sim::Mixture<T>>&>(&sim::AbstractMixing<T>::removeMixture), "Removes a mixture from the simulator.")
+		.def("addMixtureInjection", py::overload_cast<int, int, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixtureId"), py::arg("edgeId"), py::arg("injectionTime"), py::arg("isPermanent")=false, 
+			"Add a mixture injection to the simulator.")
+		.def("addMixtureInjection", py::overload_cast<const std::shared_ptr<sim::Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixture"), py::arg("edge"), 
+			py::arg("injectionTime"), py::arg("isPermanent")=false, "Add a mixture injection to the simulator")
+		.def("addPermanentMixtureInjection", py::overload_cast<int, int, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), "Add a permanent mixture injection to the simulator.")
+		.def("addPermanentMixtureInjection", py::overload_cast<const std::shared_ptr<sim::Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), 
+			"Add a permanent mixture injection to the simulator.")
+		.def("getMixtureInjection", &sim::AbstractMixing<T>::getMixtureInjection, "Returns the mixture injection with the given id.")
+		.def("removeMixtureInjection", py::overload_cast<const std::shared_ptr<sim::MixtureInjection<T>>&>(&sim::AbstractMixing<T>::removeMixtureInjection), 
+			"Removes the mixture injection with the given id.");
 
-	// py::class_<sim::HybridContinuous, sim::Simulation, py::smart_holder>(m, "HybridContinuous")
-	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
-	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-	// 			return std::shared_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
-	// 		}))
-	// 	.def("getCharacteristicLength", &sim::HybridContinuous<T>::getCharacteristicLength, "Returns the characteristic length of the LBM simulators.")
-	// 	.def("getCharacteristicVelocity", &sim::HybridContinuous<T>::getCharacteristicVelocity, "Returns the characteristic velocity of the LBM simulators.")
-	// 	.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
-	// 		py::arg("module"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
-	// 	.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
-	// 		py::arg("module"), py::arg("resolution"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
-	// 	.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, T, T, T, T, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
-	// 		py::arg("module"), py::arg("resolution"), py::arg("epsilon"), py::arg("tau"), py::arg("charPhysLength"), py::arg("charPhysVelocity"), py::arg("name")="", 
-	// 		"Add a LBM simulator to the hybrid simulation.")
-	// 	.def("getLbmSimulator", &sim::HybridContinuous<T>::getLbmSimulator, "Returns the LBM simulator with the given id.")
-	// 	.def("removeLbmSimulator", &sim::HybridContinuous<T>::removeLbmSimulator, "Removes the LBM simulator from the hybrid simulation.")
-	// 	.def("setNaiveHybridScheme", py::overload_cast<T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), "Set the naive update scheme for all simulators.")
-	// 	.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
-	// 		"Set the naive update scheme for the given simulator.")
-	// 	.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, std::unordered_map<int, T>, std::unordered_map<int, T>, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
-	// 		"Set the naive update scheme for the given simulator.")
-	// 	.def("getGlobalPressureBounds", &sim::HybridContinuous<T>::getGlobalPressureBounds, "Returns the global pressure bounds in the CFD simulators.")
-	// 	.def("getGlobalVelocityBounds", &sim::HybridContinuous<T>::getGlobalVelocityBounds, "Returns the global velocity bounds in the CFD simulators.")
-	// 	.def("writePressurePpm", &sim::HybridContinuous<T>::writePressurePpm, "Write the pressure field in ppm format for all simulators.")
-	// 	.def("writeVelocityPpm", &sim::HybridContinuous<T>::writeVelocityPpm, "Write the velocity field in ppm format for all simulators.");
+	py::class_<sim::HybridContinuous<T>, sim::Simulation<T>, py::smart_holder>(m, "HybridContinuous")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
+			}))
+		.def("getCharacteristicLength", &sim::HybridContinuous<T>::getCharacteristicLength, "Returns the characteristic length of the LBM simulators.")
+		.def("getCharacteristicVelocity", &sim::HybridContinuous<T>::getCharacteristicVelocity, "Returns the characteristic velocity of the LBM simulators.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("resolution"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, T, T, T, T, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("resolution"), py::arg("epsilon"), py::arg("tau"), py::arg("charPhysLength"), py::arg("charPhysVelocity"), py::arg("name")="", 
+			"Add a LBM simulator to the hybrid simulation.")
+		.def("getLbmSimulator", &sim::HybridContinuous<T>::getLbmSimulator, "Returns the LBM simulator with the given id.")
+		.def("removeLbmSimulator", &sim::HybridContinuous<T>::removeLbmSimulator, "Removes the LBM simulator from the hybrid simulation.")
+		.def("setNaiveHybridScheme", py::overload_cast<T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), "Set the naive update scheme for all simulators.")
+		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<sim::CFDSimulator<T>>&, T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+			"Set the naive update scheme for the given simulator.")
+		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<sim::CFDSimulator<T>>&, std::unordered_map<int, T>, std::unordered_map<int, T>, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+			"Set the naive update scheme for the given simulator.")
+		.def("getGlobalPressureBounds", &sim::HybridContinuous<T>::getGlobalPressureBounds, "Returns the global pressure bounds in the CFD simulators.")
+		.def("getGlobalVelocityBounds", &sim::HybridContinuous<T>::getGlobalVelocityBounds, "Returns the global velocity bounds in the CFD simulators.")
+		.def("writePressurePpm", &sim::HybridContinuous<T>::writePressurePpm, "Write the pressure field in ppm format for all simulators.")
+		.def("writeVelocityPpm", &sim::HybridContinuous<T>::writeVelocityPpm, "Write the velocity field in ppm format for all simulators.");
 		
 	#ifdef VERSION_INFO
 	m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/python/mmft/simulator/bindings.cpp
+++ b/python/mmft/simulator/bindings.cpp
@@ -33,15 +33,15 @@ PYBIND11_MODULE(pysimulator, m) {
 		.value("continuous", sim::Platform::Continuous)
 		.value("bigDroplet", sim::Platform::BigDroplet);
 
-	py::class_<arch::Opening>(m, "Opening")
-        .def(py::init<std::shared_ptr<NodeT>, std::vector<T>, T,T>(),
+	py::class_<arch::Opening<T>>(m, "Opening")
+        .def(py::init<std::shared_ptr<arch::Node<T>>, std::vector<T>, T,T>(),
             py::arg("node"), py::arg("normal"), py::arg("width"), py::arg("height") = 1e-4)
-		.def_readwrite("node", &arch::Opening::node)
-		.def_readwrite("normal", &arch::Opening::normal)
-		.def_readwrite("tangent", &arch::Opening::tangent)
-		.def_readwrite("width", &arch::Opening::width)
-		.def_readwrite("height", &arch::Opening::height)
-		.def_readwrite("radial", &arch::Opening::radial)
+		.def_readwrite("node", &arch::Opening<T>::node)
+		.def_readwrite("normal", &arch::Opening<T>::normal)
+		.def_readwrite("tangent", &arch::Opening<T>::tangent)
+		.def_readwrite("width", &arch::Opening<T>::width)
+		.def_readwrite("height", &arch::Opening<T>::height)
+		.def_readwrite("radial", &arch::Opening<T>::radial);
 
 	py::class_<arch::Node<T>, py::smart_holder>(m, "Node")
 		.def("getId", &arch::Node<T>::getId, "Returns the Id of the node.")
@@ -74,96 +74,97 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("isRectangular", &arch::Channel<T>::isRectangular, "Returns true if the channel has a rectangular cross-section.")
 		.def("isCylindrical", &arch::Channel<T>::isCylindrical, "Returns true if the channel has a cylindrical cross-section.");
 
-	py:class_<arch::RectangularChannel<T>, arch::Channel<T>, py::smart_holder>(m, "RectangularChannel")
+	py::class_<arch::RectangularChannel<T>, arch::Channel<T>, py::smart_holder>(m, "RectangularChannel")
 		.def("get2DFlowRate", &arch::RectangularChannel<T>::get2DFlowRate, "Maps and returns the 2-dimensional flow rate within the channel [m^2/s].")
 		.def("setWidth", &arch::RectangularChannel<T>::setWidth, "Set the width of the channel cross-section [m].")
 		.def("getWidth", &arch::RectangularChannel<T>::getWidth, "Returns the width of the channel cross-section [m].")
 		.def("setHeight", &arch::RectangularChannel<T>::setHeight, "Set the height of the channel cross-section [m].")
 		.def("getHeight", &arch::RectangularChannel<T>::getHeight, "Returns the height of the channel cross-section [m]");
 
-	py:class_<arch::CylindricalChannel<T>, arch::Channel<T>, py::smart_holder>(m, "CylindricalChannel")
+	py::class_<arch::CylindricalChannel<T>, arch::Channel<T>, py::smart_holder>(m, "CylindricalChannel")
 		.def("setRadius", &arch::CylindricalChannel<T>::setRadius, "Set the radius of the channel cross-section [m].")
-		.def("getRadius", &arch::CylindricalChannel<T>::getRadius, "Returns the radius of the channel cross-section [m].")
+		.def("getRadius", &arch::CylindricalChannel<T>::getRadius, "Returns the radius of the channel cross-section [m].");
 
 	py::class_<arch::FlowRatePump<T>, arch::Edge<T>, py::smart_holder>(m, "FlowRatePump")
-		.def("setFlowRate", &arch::CylindricalChannel<T>::setFlowRate, "Set the flow rate of the pump [m^3/s].")
+		.def("setFlowRate", &arch::FlowRatePump<T>::setFlowRate, "Set the flow rate of the pump [m^3/s].");
 
 	py::class_<arch::PressurePump<T>, arch::Edge<T>, py::smart_holder>(m, "PressurePump")
-		.def("setPressure", &arch::CylindricalChannel<T>::setPressure, "Set the pressure across the pump [Pa].")
+		.def("setPressure", &arch::PressurePump<T>::setPressure, "Set the pressure across the pump [Pa].");
 
 	py::class_<arch::Membrane<T>, arch::Edge<T>, py::smart_holder>(m, "Membrane")
-		.def("setDimensions", &arch::Membrane::setDimensions, "Set the dimensions of the membrane [w, h, l] [m].")
-		.def("setHeight", &arch::Membrane::setHeight, "Set the height of the membrane [m].")
-		.def("setWidth", &arch::Membrane::setWidth, "Set the width of the membrane [m].")
-		.def("setLength", &arch::Membrane::setLength, "Set the length of the membrane [m].")
-		.def("setPoreRadius", &arch::Membrane::setPoreRadius, "Set the pore radius of the pores of the membrane [m].")
-		.def("setPorosity", &arch::Membrane::setPorosity, "Set the porosity of the membrane [0.0-1.0].")
-		.def("setChannel", &arch::Membrane::setChannel, "Set the channel the membrane is connected to.")
-		.def("setTank", &arch::Membrane::setTank, "Set the tank the membrane is connected to.")
-		.def("getConcentrationChange", &arch::Membrane::getConcentrationChange, "Returns the concentration change caused by the membrane [mol].")
-		.def("getHeight", &arch::Membrane::getHeight, "Returns the height of the membrane [m].")
-		.def("getWidth", &arch::Membrane::getWidth, "Returns the width of the membrane [m].")
-		.def("getLength", &arch::Membrane::getLength, "Returns the length of the membrane [m].")
-		.def("getChannel", &arch::Membrane::getChannel, "Returns the channel that the membrane is connected to.")
-		.def("getTank", &arch::Membrane::getTank, "Returns the tank that the membrane is connected to.")
-		.def("getPoreRadius", &arch::Membrane::getPoreRadius, "Returns the pore radius of the membrane [m].")
-		.def("getPoreDiameter", &arch::Membrane::getPoreDiameter, "Returns the diameter of the pores of the membrane [m].")
-		.def("getPorosity", &arch::Membrane::getPorosity, "Returns the porosity of the membrane [0.0-1.0].")
-		.def("getNumberOfPores", &arch::Membrane::getNumberOfPores, "Returns the number of pores in a given area [m^2] of the membrane.")
-		.def("getPoreDensity", &arch::Membrane::getPoreDensity, "Returns the density of the pores in the membrane.")
-		.def("getArea", &arch::Membrane::getArea, "Returns the area of the membrane [m^2].")
-		.def("getVolume", &arch::Membrane::getVolume, "Returns the volume of the membrane [m^3].");
+		.def("setDimensions", &arch::Membrane<T>::setDimensions, "Set the dimensions of the membrane [w, h, l] [m].")
+		.def("setHeight", &arch::Membrane<T>::setHeight, "Set the height of the membrane [m].")
+		.def("setWidth", &arch::Membrane<T>::setWidth, "Set the width of the membrane [m].")
+		.def("setLength", &arch::Membrane<T>::setLength, "Set the length of the membrane [m].")
+		.def("setPoreRadius", &arch::Membrane<T>::setPoreRadius, "Set the pore radius of the pores of the membrane [m].")
+		.def("setPorosity", &arch::Membrane<T>::setPorosity, "Set the porosity of the membrane [0.0-1.0].")
+		.def("setChannel", &arch::Membrane<T>::setChannel, "Set the channel the membrane is connected to.")
+		.def("setTank", &arch::Membrane<T>::setTank, "Set the tank the membrane is connected to.")
+		.def("getConcentrationChange", &arch::Membrane<T>::getConcentrationChange, "Returns the concentration change caused by the membrane [mol].")
+		.def("getHeight", &arch::Membrane<T>::getHeight, "Returns the height of the membrane [m].")
+		.def("getWidth", &arch::Membrane<T>::getWidth, "Returns the width of the membrane [m].")
+		.def("getLength", &arch::Membrane<T>::getLength, "Returns the length of the membrane [m].")
+		.def("getChannel", &arch::Membrane<T>::getChannel, "Returns the channel that the membrane is connected to.")
+		.def("getTank", &arch::Membrane<T>::getTank, "Returns the tank that the membrane is connected to.")
+		.def("getPoreRadius", &arch::Membrane<T>::getPoreRadius, "Returns the pore radius of the membrane [m].")
+		.def("getPoreDiameter", &arch::Membrane<T>::getPoreDiameter, "Returns the diameter of the pores of the membrane [m].")
+		.def("getPorosity", &arch::Membrane<T>::getPorosity, "Returns the porosity of the membrane [0.0-1.0].")
+		.def("getNumberOfPores", &arch::Membrane<T>::getNumberOfPores, "Returns the number of pores in a given area [m^2] of the membrane.")
+		.def("getPoreDensity", &arch::Membrane<T>::getPoreDensity, "Returns the density of the pores in the membrane.")
+		.def("getArea", &arch::Membrane<T>::getArea, "Returns the area of the membrane [m^2].")
+		.def("getVolume", &arch::Membrane<T>::getVolume, "Returns the volume of the membrane [m^3].");
 
 	py::class_<arch::Tank<T>, arch::Edge<T>, py::smart_holder>(m, "Tank")
-		.def("setDimensions", &arch::Tank::setDimensions, "Set the dimensions of the tank [w, h, l] [m].")
-		.def("setHeight", &arch::Tank::setHeight, "Set the height of the tank [m].")
-		.def("setWidth", &arch::Tank::setWidth, "Set the width of the tank [m].")
-		.def("setLength", &arch::Tank::setLength, "Set the length of the tank [m].")
-		.def("getHeight", &arch::Tank::getHeight, "Returns the height of the tank [m].")
-		.def("getWidth", &arch::Tank::getWidth, "Returns the width of the tank [m].")
-		.def("getLength", &arch::Tank::getLength, "Returns the length of the tank [m].")
-		.def("getArea", &arch::Tank::getArea, "Returns the area of the tank [m^2].")
-		.def("getVolume", &arch::Tank::getVolume, "Returns the volume of the tank [m^3].");
+		.def("setDimensions", &arch::Tank<T>::setDimensions, "Set the dimensions of the tank [w, h, l] [m].")
+		.def("setHeight", &arch::Tank<T>::setHeight, "Set the height of the tank [m].")
+		.def("setWidth", &arch::Tank<T>::setWidth, "Set the width of the tank [m].")
+		.def("setLength", &arch::Tank<T>::setLength, "Set the length of the tank [m].")
+		.def("getHeight", &arch::Tank<T>::getHeight, "Returns the height of the tank [m].")
+		.def("getWidth", &arch::Tank<T>::getWidth, "Returns the width of the tank [m].")
+		.def("getLength", &arch::Tank<T>::getLength, "Returns the length of the tank [m].")
+		.def("getArea", &arch::Tank<T>::getArea, "Returns the area of the tank [m^2].")
+		.def("getVolume", &arch::Tank<T>::getVolume, "Returns the volume of the tank [m^3].");
 
 	py::class_<arch::Module<T>, py::smart_holder>(m, "Module")
-		.def("getId", &arch::Module::getId, "Returns the id of the module.")
-		.def("getPosition", &arch::Module::getPosition, "Returns the position [x, y] of the bottom left corner w.r.t. the device [m].")
-		.def("getSize", &arch::Module::getSize, "Returns the size [x, y] of the module [m].")
-		.def("getNodes", &arch::Module::getNodes, "Returns a map of nodes that are on the module's edges.")
-		.def("setModuleTypeLbm", &arch::Module::setModuleTypeLbm, "Set the type of the module to lbm simulator.")
-		.def("getModuleType", &arch::Module::getModuleType, "Returns the type of the module.");
+		.def("getId", &arch::Module<T>::getId, "Returns the id of the module.")
+		.def("getPosition", &arch::Module<T>::getPosition, "Returns the position [x, y] of the bottom left corner w.r.t. the device [m].")
+		.def("getSize", &arch::Module<T>::getSize, "Returns the size [x, y] of the module [m].")
+		.def("getNodes", &arch::Module<T>::getNodes, "Returns a map of nodes that are on the module's edges.")
+		.def("setModuleTypeLbm", &arch::Module<T>::setModuleTypeLbm, "Set the type of the module to lbm simulator.")
+		.def("getModuleType", &arch::Module<T>::getModuleType, "Returns the type of the module.");
 
 	py::class_<arch::CfdModule<T>, arch::Module<T>, py::smart_holder>(m, "CfdModule")
-		.def("assertInitialized", &arch::CfdModule::assertInitialized, "Checks whether the CFD module has valid openings and STL definitions.")
-		.def("getNetwork", &arch::CfdModule::getNetwork, "Returns a graph network that fully connects the module's boundary nodes.")
-		.def("getOpenings", &arch::CfdModule::getOpenings, "Returns a map of the openings of the module.")
-		.def("getStlFile", &arch::Module::getStlFile, "Returns the STL file that defines the CFD domain.");
+		.def("assertInitialized", &arch::CfdModule<T>::assertInitialized, "Checks whether the CFD module has valid openings and STL definitions.")
+		.def("getNetwork", &arch::CfdModule<T>::getNetwork, "Returns a graph network that fully connects the module's boundary nodes.")
+		.def("getOpenings", &arch::CfdModule<T>::getOpenings, "Returns a map of the openings of the module.")
+		.def("getStlFile", &arch::CfdModule<T>::getStlFile, "Returns the STL file that defines the CFD domain.");
 
 	py::class_<arch::Network<T>, py::smart_holder>(m, "Network")
 		.def("isNetworkValid", &arch::Network<T>::isNetworkValid, "Check if the current network is valid.")
-		.def("", &arch::Network<T>::, "")
+		.def("toJson", &arch::Network<T>::toJson, "Store the network object in a JSON file.")
 		.def("print", &arch::Network<T>::print, "Print the content of this network.")
 		// Nodes
-		.def("addNode", py::overload_cast<T, T, bool>(&arch::Network<T>::addNode), "Add a new node to the network.")
+		.def("addNode", py::overload_cast<T, T, bool>(&arch::Network<T>::addNode), 
+			py::arg("x"), py::arg("y"), py::arg("ground")=false, "Add a new node to the network.")
 		.def("getNode", &arch::Network<T>::getNode, "Returns the node with the given id.")
 		.def("getNodes", &arch::Network<T>::getNodes, "Returns all nodes in the network.")
 		.def("getGroundNodes", &arch::Network<T>::getGroundNodes, "Returns the set of nodes that are ground nodes.")
 		.def("getGroundNodeIds", &arch::Network<T>::getGroundNodeIds, "Returns the ids of the set of ground nodes.")
 		.def("getVirtualNodes", &arch::Network<T>::getVirtualNodes, "Returns the amount of virtual nodes in the network.")
 		.def("setVirtualNodes", &arch::Network<T>::setVirtualNodes, "Sets the amount of virtual nodes in the network.")
-		.def("hasNode", py::overload_cast<size_t>(&arch::Network<T>::addNode), "Returns true if the network contains the node with the given id.")
-		.def("hasNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::addNode), "Returns true if the network contains the given node.")
+		.def("hasNode", py::overload_cast<size_t>(&arch::Network<T>::hasNode, py::const_), "Returns true if the network contains the node with the given id.")
+		.def("hasNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::hasNode, py::const_), "Returns true if the network contains the given node.")
 		.def("setSink", py::overload_cast<size_t>(&arch::Network<T>::setSink), "Sets the node with given id to be a sink node.")
 		.def("setSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::setSink), "Sets the given node to be a sink node.")
-		.def("isSink", py::overload_cast<size_t>(&arch::Network<T>::isSink), "Returns true if the node of the given id is a sink node.")
-		.def("isSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isSink), "Returns true if the given node is a sink node.")
+		.def("isSink", py::overload_cast<size_t>(&arch::Network<T>::isSink, py::const_), "Returns true if the node of the given id is a sink node.")
+		.def("isSink", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isSink, py::const_), "Returns true if the given node is a sink node.")
 		.def("setGround", py::overload_cast<size_t>(&arch::Network<T>::setGround), "Sets the node with given id to be a ground node.")
 		.def("setGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::setGround), "Sets the given node to be a ground node.")
-		.def("isGround", py::overload_cast<size_t>(&arch::Network<T>::isGround), "Returns true if the node of the given id is a ground node.")
-		.def("isGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isGround), "Returns true if the given node is a ground node.")
-		.def("calculateNodeDistance", py::overload_cast<size_t, size_t>(&arch::Network<T>::calculateNodeDistance), 
+		.def("isGround", py::overload_cast<size_t>(&arch::Network<T>::isGround, py::const_), "Returns true if the node of the given id is a ground node.")
+		.def("isGround", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::isGround, py::const_), "Returns true if the given node is a ground node.")
+		.def("calculateNodeDistance", py::overload_cast<size_t, size_t>(&arch::Network<T>::calculateNodeDistance, py::const_), 
 			"Calculates the Euclidean distance between the nodes of the given ids.")
-		.def("calculateNodeDistance", py::overload_cast<std::shared_ptr<Node<T>>, std::shared_ptr<Node<T>>>(&arch::Network<T>::calculateNodeDistance), 
+		.def("calculateNodeDistance", py::overload_cast<std::shared_ptr<arch::Node<T>>, std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::calculateNodeDistance, py::const_), 
 			"Calculates the Euclidean distance between the two given nodes.")
 		.def("removeNode", &arch::Network<T>::removeNode, "Removes the given node from the network.")
 		// Channels
@@ -182,12 +183,12 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getChannel", &arch::Network<T>::getChannel, "Returns the channel with the given id.")
 		.def("getRectangularChannel", &arch::Network<T>::getRectangularChannel, "Returns the channel with the given id, if it is a rectangular channel.")
 		.def("getChannels", &arch::Network<T>::getChannels, "Returns all channels in the network.")
-		.def("getChannelsAtNode", py::overload_cast<size_t>(&arch::Network<T>::getChannelsAtNode), 
+		.def("getChannelsAtNode", py::overload_cast<size_t>(&arch::Network<T>::getChannelsAtNode, py::const_), 
 				"Returns all channels in the network that are connected to the node with the given id.")
-		.def("getChannelsAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getChannelsAtNode), 
+		.def("getChannelsAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getChannelsAtNode, py::const_), 
 			"Returns all channels in the network that are connected to the given node.")
-		.def("isChannel", py::overload_cast<int>(&arch::Network<T>::isChannel), "Returns true if the edge with the given id is a channel.")
-		.def("isChannel", py::overload_cast<const std::shared_ptr<arch::Edge<T>>&>(&arch::Network<T>::isChannel), "Returns true if the given edge is a channel.")
+		.def("isChannel", py::overload_cast<int>(&arch::Network<T>::isChannel, py::const_), "Returns true if the edge with the given id is a channel.")
+		.def("isChannel", py::overload_cast<const std::shared_ptr<arch::Edge<T>>&>(&arch::Network<T>::isChannel, py::const_), "Returns true if the given edge is a channel.")
 		.def("removeChannel", &arch::Network<T>::removeChannel, "Remove the given channel from the network.")
 		// Pumps
 		.def("addFlowRatePump", &arch::Network<T>::addFlowRatePump, "Add a flow rate pump to the network.")
@@ -212,24 +213,24 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("addMembraneToChannel", py::overload_cast<const std::shared_ptr<arch::Channel<T>>&, T, T, T, T>(&arch::Network<T>::addMembraneToChannel), 
 			"Adds a membrane to a channel in the network.")
 		.def("getMembrane", &arch::Network<T>::getMembrane, "Returns the membrane with the given id.")
-		.def("getMembraneBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getMembraneBetweenNodes), 
+		.def("getMembraneBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getMembraneBetweenNodes, py::const_), 
 			"Returns the membrane between two given nodes.")
-		.def("getMembraneBetweenNodes", py::overload_cast<const std::shared_ptr<Node<T>>&, const std::shared_ptr<Node<T>>&>(&arch::Network<T>::getMembraneBetweenNodes), 
+		.def("getMembraneBetweenNodes", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&>(&arch::Network<T>::getMembraneBetweenNodes, py::const_), 
 			"Returns the membrane between two given nodes.")
 		.def("getMembranes", &arch::Network<T>::getMembranes, "Returns all membranes in the network.")
-		.def("getMembranesAtNode", py::overload_cast<size_t>(&arch::Network<T>::getMembranesAtNode), 
+		.def("getMembranesAtNode", py::overload_cast<size_t>(&arch::Network<T>::getMembranesAtNode, py::const_), 
 			"Returns the set of membranes that are at the given node.")
-		.def("getMembranesAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getMembranesAtNode), 
+		.def("getMembranesAtNode", py::overload_cast<std::shared_ptr<arch::Node<T>>>(&arch::Network<T>::getMembranesAtNode, py::const_), 
 			"Returns the set of membranes that are at the given node.")
 		.def("isMembrane", &arch::Network<T>::isMembrane, "Returns true if the given edge id belongs to a membrane.")
 		// Tank
-		.def("addTankToMembrane", py::overload_cast<size_t, T, T, T, T>(&arch::Network<T>::addTankToMembrane), "Adds a tank to a membrane in the network.")
-		.def("addTankToMembrane", py::overload_cast<const std::shared_ptr<arch::Channel<T>>&, T, T, T, T>(&arch::Network<T>::addTankToMembrane), 
+		.def("addTankToMembrane", py::overload_cast<size_t, T, T>(&arch::Network<T>::addTankToMembrane), "Adds a tank to a membrane in the network.")
+		.def("addTankToMembrane", py::overload_cast<const std::shared_ptr<arch::Membrane<T>>&, T, T>(&arch::Network<T>::addTankToMembrane), 
 			"Adds a tank to a membrane in the network.")
 		.def("getTank", &arch::Network<T>::getTank, "Returns the tank with the given id.")
-		.def("getTankBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getTankBetweenNodes), 
+		.def("getTankBetweenNodes", py::overload_cast<size_t, size_t>(&arch::Network<T>::getTankBetweenNodes, py::const_), 
 			"Returns the tank between two given nodes.")
-		.def("getTankBetweenNodes", py::overload_cast<const std::shared_ptr<Node<T>>&, const std::shared_ptr<Node<T>>&>(&arch::Network<T>::getTankBetweenNodes), 
+		.def("getTankBetweenNodes", py::overload_cast<const std::shared_ptr<arch::Node<T>>&, const std::shared_ptr<arch::Node<T>>&>(&arch::Network<T>::getTankBetweenNodes, py::const_), 
 			"Returns the tank between two given nodes.")
 		.def("getTanks", &arch::Network<T>::getTanks, "Returns all tanks in the network.");
 		
@@ -261,10 +262,12 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("setName", &sim::Droplet<T>::setName, "Sets the name of the droplet.")
 		.def("getVolume", &sim::Droplet<T>::getVolume, "Returns the volume of the droplet [m^3].")
 		.def("setVolume", &sim::Droplet<T>::setVolume, "Sets the volume of the droplet [m^3].")
-		.def("readFluid", &sim::Droplet<T>::readFluid, "Returns a read-only reference to the Fluid that constitutes the droplet.")
+		.def("readFluid", &sim::Droplet<T>::readFluid, py::return_value_policy::reference, 
+			"Returns a read-only reference to the Fluid that constitutes the droplet.")
 		.def("setFluid", &sim::Droplet<T>::setFluid, "Sets the fluid that the droplet consists of.")
-		.def("readBoundaries", &sim::Droplet<T>::readBoundaries, "Returns a read-only list of the droplet boundaries.")
-		.def("readFullyOccupiedChannels", &sim::Droplet<T>::readFullyOccupiedChannels, 
+		.def("readBoundaries", &sim::Droplet<T>::readBoundaries, py::return_value_policy::reference, 
+			"Returns a read-only list of the droplet boundaries.")
+		.def("readFullyOccupiedChannels", &sim::Droplet<T>::readFullyOccupiedChannels, py::return_value_policy::reference, 
 			"Returns a read-only list of the channels that the droplet occupies fully.");
 
 	py::class_<sim::Specie<T>, py::smart_holder>(m, "Specie")
@@ -282,209 +285,212 @@ PYBIND11_MODULE(pysimulator, m) {
 		.def("getName", &sim::Mixture<T>::getName, "Returns the name of the mixture.")
 		.def("setName", &sim::Mixture<T>::setName, "Sets the name of the mixture.")
 		//.def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("addSpecie", &sim::Mixture<T>::addSpecie, "Adds a specie with a given concentration to this mixture.")
+		.def("addSpecie", py::overload_cast<std::shared_ptr<sim::Specie<T>>&, T>(&sim::Mixture<T>::addSpecie), 
+			"Adds a specie with a given concentration to this mixture.")
 		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
 		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
 		.def("readSpecieConcentrations", &sim::Mixture<T>::readSpecieConcentrations, "Returns a read-only map of the specie concentrations.")
 		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("getConcentrationOfSpecie", &sim::Mixture<T>::getConcentrationOfSpecie, "Returns the concentration of a specie [TODO].")
-		.def("getSpecieDistributions", &sim::Mixture<T>::getSpecieDistributions, "Returns the concentration distribution of a species if it's not a constant value [TODO].")
+		.def("getConcentrationOfSpecie", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::Mixture<T>::getConcentrationOfSpecie, py::const_), 
+			"Returns the concentration of a specie [TODO].")
+		.def("getSpecieDistributions", py::overload_cast<>(&sim::Mixture<T>::getSpecieDistributions, py::const_), 
+			"Returns the concentration distribution of a species if it's not a constant value [TODO].")
 		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("setSpecieConcentration", &sim::Mixture<T>::setSpecieConcentration, "Sets the concentration of a specie [TODO].")
+		.def("setSpecieConcentration", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::Mixture<T>::setSpecieConcentration), "Sets the concentration of a specie [TODO].")
 		.def("getSpecieCount", &sim::Mixture<T>::getSpecieCount, "Returns the number of species listed in the mixture.")
 		// .def("", &sim::Mixture<T>::, "") <- Shouldn't be able to own a raw pointer
-		.def("removeSpecie", &sim::Mixture<T>::removeSpecie, "Removes a specie from the mixture.")
+		.def("removeSpecie", py::overload_cast<std::shared_ptr<sim::Specie<T>>&>(&sim::Mixture<T>::removeSpecie), "Removes a specie from the mixture.")
 		.def("getDensity", &sim::Mixture<T>::getDensity, "Returns the density of the mixture [kg/m^3].")
 		.def("getViscosity", &sim::Mixture<T>::getViscosity, "Returns the viscosity of the mixture [Pa s].")
 		.def("getLargestMolecularSize", &sim::Mixture<T>::getLargestMolecularSize, "Returns the largest molecular size of the species in the mixture.");
 
-	py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
-		.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
-		.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.")
+	// py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
+	// 	.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
+	// 	.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.");
 
-	py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
-		.def("getId", &sim::DropletInjection<T>getId, "Returns the id of the droplet injection.")
-		.def("getName", &sim::DropletInjection<T>getName, "Returns the name of the droplet injection.")
-		.def("setName", &sim::DropletInjection<T>setName, "Sets the name of the droplet inkection.")
-		.def("getInjectionTime", &sim::DropletInjection<T>getInjectionTime, "Returns the time at which the droplet is injected [s].")
-		.def("setInjectionTime", &sim::DropletInjection<T>setInjectionTime, "Sets the time at which the droplet should be injected [s].")
-		// Encapsulation -> Why do we set and return the ChannelPosition object, and not just channel and position parameters?
-		.def("getInjectionPosition", &sim::DropletInjection<T>getInjectionPosition, "Returns the channel and position at which the droplet is injected.")
-		.def("setInjectionPosition", &sim::DropletInjection<T>setInjectionPosition, "Sets the channel and position at which the droplet is injected.");
+	// py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
+	// 	.def("getId", &sim::DropletInjection<T>getId, "Returns the id of the droplet injection.")
+	// 	.def("getName", &sim::DropletInjection<T>getName, "Returns the name of the droplet injection.")
+	// 	.def("setName", &sim::DropletInjection<T>setName, "Sets the name of the droplet inkection.")
+	// 	.def("getInjectionTime", &sim::DropletInjection<T>getInjectionTime, "Returns the time at which the droplet is injected [s].")
+	// 	.def("setInjectionTime", &sim::DropletInjection<T>setInjectionTime, "Sets the time at which the droplet should be injected [s].")
+	// 	// Encapsulation -> Why do we set and return the ChannelPosition object, and not just channel and position parameters?
+	// 	.def("getInjectionPosition", &sim::DropletInjection<T>getInjectionPosition, "Returns the channel and position at which the droplet is injected.")
+	// 	.def("setInjectionPosition", &sim::DropletInjection<T>setInjectionPosition, "Sets the channel and position at which the droplet is injected.");
 
-	py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
-		.def("getId", &sim::MixtureInjection<T>getId, "Returns the id of the mixture injection.")
-		.def("getName", &sim::MixtureInjection<T>getName, "Returns the name of the mixture injection.")
-		.def("setName", &sim::MixtureInjection<T>setName, "Sets the name of the mixture inkection.")
-		.def("getInjectionTime", &sim::MixtureInjection<T>getInjectionTime, "Returns the time at which the mixture is injected [s].")
-		.def("setInjectionTime", &sim::MixtureInjection<T>setInjectionTime, "Sets the time at which the mixture should be injected [s].")
-		.def("getInjectionChannel", &sim::MixtureInjection<T>getInjectionChannel, "Returns the channel into which the mixture is injected.")
-		.def("setInjectionChannel", &sim::MixtureInjection<T>setInjectionChannel, "Sets the channel into which the mixture is injected.");
+	// py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
+	// 	.def("getId", &sim::MixtureInjection<T>getId, "Returns the id of the mixture injection.")
+	// 	.def("getName", &sim::MixtureInjection<T>getName, "Returns the name of the mixture injection.")
+	// 	.def("setName", &sim::MixtureInjection<T>setName, "Sets the name of the mixture inkection.")
+	// 	.def("getInjectionTime", &sim::MixtureInjection<T>getInjectionTime, "Returns the time at which the mixture is injected [s].")
+	// 	.def("setInjectionTime", &sim::MixtureInjection<T>setInjectionTime, "Sets the time at which the mixture should be injected [s].")
+	// 	.def("getInjectionChannel", &sim::MixtureInjection<T>getInjectionChannel, "Returns the channel into which the mixture is injected.")
+	// 	.def("setInjectionChannel", &sim::MixtureInjection<T>setInjectionChannel, "Sets the channel into which the mixture is injected.");
 
-	py::class_<sim::CFDSimulator<T>, py::smart_holder>(m, "CFDSimulator")
-		.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
-		.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
-		.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
-		// .def("getInitialized", &sim::CFDSimulator<T>::getInitialized, "Returns whether the simulator is initialized or not.")
-		// .def("setInitialized", &sim::CFDSimulator<T>::, "")
-		.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
-		.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
-		.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
-		.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
-		// .def("storeConcentrations", &sim::CFDSimulator<T>::, "")
-		// .def("getConcentrations", &sim::CFDSimulator<T>::, "")
-		// .def("setBoundaryValues", &sim::CFDSimulator<T>::, "")
-		.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
-		.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
-		.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
-		.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
-		.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.")
-		// .def("storeCfdResults", &sim::CFDSimulator<T>::, "");
+	// py::class_<sim::CFDSimulator<T>, py::smart_holder>(m, "CFDSimulator")
+	// 	.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
+	// 	.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
+	// 	.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
+	// 	// .def("getInitialized", &sim::CFDSimulator<T>::getInitialized, "Returns whether the simulator is initialized or not.")
+	// 	// .def("setInitialized", &sim::CFDSimulator<T>::, "")
+	// 	.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
+	// 	.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
+	// 	.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
+	// 	.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
+	// 	// .def("storeConcentrations", &sim::CFDSimulator<T>::, "")
+	// 	// .def("getConcentrations", &sim::CFDSimulator<T>::, "")
+	// 	// .def("setBoundaryValues", &sim::CFDSimulator<T>::, "")
+	// 	.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
+	// 	.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
+	// 	.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
+	// 	.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
+	// 	.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.")
+	// 	// .def("storeCfdResults", &sim::CFDSimulator<T>::, "");
 
-	py::class_<sim::lbmSimulator, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
-		.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
-		.def("getCharPhysVelocity", &sim::lbmSimulator<T>::getCharPhysVelocity, "Returns the characteristic physical velocity of the lbm simulator.")
-		.def("getResolution", &sim::lbmSimulator<T>::getResolution, "Returns the resolution of the lbm simulator.")
-		.def("setResolution", &sim::lbmSimulator<T>::setResolution, "Sets the resolution of the lbm simulator.")
-		.def("getEpsilon", &sim::lbmSimulator<T>::getEpsilon, "Returns the epsilon for the simulator.")
-		.def("setEpsilon", &sim::lbmSimulator<T>::setEpsilon, "Sets the epsilon for the simulator.")
-		.def("getTau", &sim::lbmSimulator<T>::getTau, "Returns the relaxation time of the simulator.")
-		.def("setTau", &sim::lbmSimulator<T>::setTau, "Sets the relaxation time of the simulator.")
-		.def("getStepIter", &sim::lbmSimulator<T>::getStepIter, "Returns the number of steps used for the value tracer (default = 1000).")
-		.def("hasConverged", &sim::lbmSimulator<T>::hasConverged, "Returns whether the simulator has converged or not.");
+	// py::class_<sim::lbmSimulator, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
+	// 	.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
+	// 	.def("getCharPhysVelocity", &sim::lbmSimulator<T>::getCharPhysVelocity, "Returns the characteristic physical velocity of the lbm simulator.")
+	// 	.def("getResolution", &sim::lbmSimulator<T>::getResolution, "Returns the resolution of the lbm simulator.")
+	// 	.def("setResolution", &sim::lbmSimulator<T>::setResolution, "Sets the resolution of the lbm simulator.")
+	// 	.def("getEpsilon", &sim::lbmSimulator<T>::getEpsilon, "Returns the epsilon for the simulator.")
+	// 	.def("setEpsilon", &sim::lbmSimulator<T>::setEpsilon, "Sets the epsilon for the simulator.")
+	// 	.def("getTau", &sim::lbmSimulator<T>::getTau, "Returns the relaxation time of the simulator.")
+	// 	.def("setTau", &sim::lbmSimulator<T>::setTau, "Sets the relaxation time of the simulator.")
+	// 	.def("getStepIter", &sim::lbmSimulator<T>::getStepIter, "Returns the number of steps used for the value tracer (default = 1000).")
+	// 	.def("hasConverged", &sim::lbmSimulator<T>::hasConverged, "Returns whether the simulator has converged or not.");
 
-	py::class_<sim::Simulation, py::smart_holder>(m, "Simulation")
-		.def("getPlatform", &sim::Simulation<T>::getPlatorm, "Returns the platform of the simulation.")
-		.def("getType", &sim::Simulation<T>::getType, "Returns the type of simulation [Abstract, Hybrid CFD].")
-		.def("getNetwork", &sim::Simulation<T>::getNetwork, "Returns the network on which the simulation is conducted.")
-		.def("setNetwork", &sim::Simulation<T>::setNetwork, "Sets the network on which the simulation is conducted.")
-		.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
-		.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
-		.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
-		.def("addMixedFluid", &sim::Simulation<T>::addMixedFluid, "Creates and adds a new fluid from two existing fluids.")
-		.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
-		.def("readFluids", &sim::Simulation<T>::readFluids, "Returns a read-only list of fluids.")
-		.def("removeFluid", &sim::Simulation<T>::removeFluid, "Removes a fluid from the simulation.")
-		.def("getFixtureId", &sim::Simulation<T>::getFixtureId, "Returns the fixture id.")
-		.def("setFixtureId", &sim::Simulation<T>::setFixtureId, "Sets the fixture id.")
-		.def("getContinuousPhase", &sim::Simulation<T>::getContinuousPhase, "Returns the continuous phase of the simulation.")
-		.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the fluid with the given id.")
-		.def("setContinuousPhase", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the given fluid.")
-		.def("getCurrentIteration", &sim::Simulation<T>::getCurrentIteration, "Returns the current iteration number.")
-		.def("getMaxIterations", &sim::Simulation<T>::getMaxIterations, "Returns the maximum number of allowed iterations. When reached the simulation ends.")
-		.def("setWriteInterval", &sim::Simulation<T>::setWriteInterval, "Set the iterations interval at which the stat is saved in the results.")
-		.def("getTMax", &sim::Simulation<T>::getTMax, "Returns the maximum allowed physical time. When reached the simulation ends.")
-		.def("setMaxEndTime", &sim::Simulation<T>::setMaxEndTime, "Set the maximal physical time after which the simulation ends.")
-		.def("getResults", &sim::Simulation<T>::getResults, "Returns the results of the simulation.")
-		.def("printResults", &sim::Simulation<T>::printResults, "Prints the results of the simulation to the console.")
-		.def("simulate", &sim::Simulation<T>::simulate, "Conducts the simulation.");
+	// py::class_<sim::Simulation, py::smart_holder>(m, "Simulation")
+	// 	.def("getPlatform", &sim::Simulation<T>::getPlatorm, "Returns the platform of the simulation.")
+	// 	.def("getType", &sim::Simulation<T>::getType, "Returns the type of simulation [Abstract, Hybrid CFD].")
+	// 	.def("getNetwork", &sim::Simulation<T>::getNetwork, "Returns the network on which the simulation is conducted.")
+	// 	.def("setNetwork", &sim::Simulation<T>::setNetwork, "Sets the network on which the simulation is conducted.")
+	// 	.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
+	// 	.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
+	// 	.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
+	// 	.def("addMixedFluid", &sim::Simulation<T>::addMixedFluid, "Creates and adds a new fluid from two existing fluids.")
+	// 	.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
+	// 	.def("readFluids", &sim::Simulation<T>::readFluids, "Returns a read-only list of fluids.")
+	// 	.def("removeFluid", &sim::Simulation<T>::removeFluid, "Removes a fluid from the simulation.")
+	// 	.def("getFixtureId", &sim::Simulation<T>::getFixtureId, "Returns the fixture id.")
+	// 	.def("setFixtureId", &sim::Simulation<T>::setFixtureId, "Sets the fixture id.")
+	// 	.def("getContinuousPhase", &sim::Simulation<T>::getContinuousPhase, "Returns the continuous phase of the simulation.")
+	// 	.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the fluid with the given id.")
+	// 	.def("setContinuousPhase", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the given fluid.")
+	// 	.def("getCurrentIteration", &sim::Simulation<T>::getCurrentIteration, "Returns the current iteration number.")
+	// 	.def("getMaxIterations", &sim::Simulation<T>::getMaxIterations, "Returns the maximum number of allowed iterations. When reached the simulation ends.")
+	// 	.def("setWriteInterval", &sim::Simulation<T>::setWriteInterval, "Set the iterations interval at which the stat is saved in the results.")
+	// 	.def("getTMax", &sim::Simulation<T>::getTMax, "Returns the maximum allowed physical time. When reached the simulation ends.")
+	// 	.def("setMaxEndTime", &sim::Simulation<T>::setMaxEndTime, "Set the maximal physical time after which the simulation ends.")
+	// 	.def("getResults", &sim::Simulation<T>::getResults, "Returns the results of the simulation.")
+	// 	.def("printResults", &sim::Simulation<T>::printResults, "Prints the results of the simulation to the console.")
+	// 	.def("simulate", &sim::Simulation<T>::simulate, "Conducts the simulation.");
 
-	py::class_<sim::AbstractContinuous, sim::Simulation, py::smart_holder>(m, "AbstractContinuous")
-		.def(py::init<std::shared_ptr<arch::Network<T>>>())
-		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::shared_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
-			}));
+	// py::class_<sim::AbstractContinuous, sim::Simulation, py::smart_holder>(m, "AbstractContinuous")
+	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
+	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+	// 			return std::shared_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
+	// 		}));
 
-	py::class_<sim::AbstractDroplet, sim::Simulation, py::smart_holder>(m, "AbstractDroplet")
-		.def(py::init<std::shared_ptr<arch::Network<T>>>())
-		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::shared_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
-			}))
-		.def("addDroplet", py::overload_cast<int, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet of the given fluid id to the simulation.")
-		.def("addDroplet", py::overload_cast<const std::shared_ptr<Fluid<T>>&, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet to the simulation.")
-		.def("addMergedDroplet", py::overload_cast<int, int>(&sim::AbstractDroplet<T>::addMergedDroplet), 
-			"Adds a droplet to the simulator, based on the ids of two existing droplets.")
-		.def("addMergedDroplet", py::overload_cast<const std::shared_ptr<Droplet<T>>&, const std::shared_ptr<Droplet<T>>&>(&sim::AbstractDroplet<T>::addMergedDroplet), 
-			"Adds a droplet to the simulator, based on two existing droplets.")
-		.def("getDroplet", &sim::AbstractDroplet<T>::getDroplet, "Returns the droplet with the given id.")
-		.def("getDropletAtNode", py::overload_cast<int>(&sim::AbstractDroplet<T>::getDropletAtNode), 
-			"Checks whether a droplet is present at the node with the given id. Returns true and the droplet if one is found.")
-		.def("getDropletAtNode", py::overload_cast<const std::shared_ptr<arch::Node<T>>&>(&sim::AbstractDroplet<T>::getDropletAtNode), 
-			"Checks whether a droplet is present at the given node. Returns true and the droplet if one is found.")
-		.def("removeDroplet", &sim::AbstractDroplet<T>::removeDroplet, "Removes a droplet from the simulation.")
-		.def("addDropletInjection", py::overload_cast<int, T, int, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
-			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
-		.def("addDropletInjection", py::overload_cast<const std::shared_ptr<Droplet<T>>&, T, const std::shared_ptr<arch::Channel<T>>&, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
-			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
-		.def("getDropletInjection", &sim::AbstractDroplet<T>::getDropletInjection, "Returns the droplet injection with the given id.")
-		.def("removeDropletInjection", &sim::AbstractDroplet<T>::removeDropletInjection, "Removes the droplet injection from the simulation.");
+	// py::class_<sim::AbstractDroplet, sim::Simulation, py::smart_holder>(m, "AbstractDroplet")
+	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
+	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+	// 			return std::shared_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
+	// 		}))
+	// 	.def("addDroplet", py::overload_cast<int, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet of the given fluid id to the simulation.")
+	// 	.def("addDroplet", py::overload_cast<const std::shared_ptr<Fluid<T>>&, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet to the simulation.")
+	// 	.def("addMergedDroplet", py::overload_cast<int, int>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+	// 		"Adds a droplet to the simulator, based on the ids of two existing droplets.")
+	// 	.def("addMergedDroplet", py::overload_cast<const std::shared_ptr<Droplet<T>>&, const std::shared_ptr<Droplet<T>>&>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+	// 		"Adds a droplet to the simulator, based on two existing droplets.")
+	// 	.def("getDroplet", &sim::AbstractDroplet<T>::getDroplet, "Returns the droplet with the given id.")
+	// 	.def("getDropletAtNode", py::overload_cast<int>(&sim::AbstractDroplet<T>::getDropletAtNode), 
+	// 		"Checks whether a droplet is present at the node with the given id. Returns true and the droplet if one is found.")
+	// 	.def("getDropletAtNode", py::overload_cast<const std::shared_ptr<arch::Node<T>>&>(&sim::AbstractDroplet<T>::getDropletAtNode), 
+	// 		"Checks whether a droplet is present at the given node. Returns true and the droplet if one is found.")
+	// 	.def("removeDroplet", &sim::AbstractDroplet<T>::removeDroplet, "Removes a droplet from the simulation.")
+	// 	.def("addDropletInjection", py::overload_cast<int, T, int, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+	// 		"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+	// 	.def("addDropletInjection", py::overload_cast<const std::shared_ptr<Droplet<T>>&, T, const std::shared_ptr<arch::Channel<T>>&, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+	// 		"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+	// 	.def("getDropletInjection", &sim::AbstractDroplet<T>::getDropletInjection, "Returns the droplet injection with the given id.")
+	// 	.def("removeDropletInjection", &sim::AbstractDroplet<T>::removeDropletInjection, "Removes the droplet injection from the simulation.");
 
-	py::class_<sim::AbstractMembrane, sim::Simulation, py::smart_holder>(m, "AbstractMembrane")
-		.def(py::init<std::shared_ptr<arch::Network<T>>>())
-		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
-			}))
-		.def("setPermeabilityMembraneModel", &sim::AbstractMembrane<T>::setPermeabilityMembraneModel, "Sets the permeability membrane model.")
-		.def("setPoreResistanceMembraneModel", &sim::AbstractMembrane<T>::setPoreResistanceMembraneModel, "Sets the pore resistance membrane model.")
-		.def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
-		.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
-		.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
-		.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")
-		.def("setMembraneModel4", &sim::AbstractMembrane<T>::setMembraneModel4, "Sets membrane model 4.")
-		.def("setMembraneModel5", &sim::AbstractMembrane<T>::setMembraneModel5, "Sets membrane model 5.")
-		.def("setMembraneModel6", &sim::AbstractMembrane<T>::setMembraneModel6, "Sets membrane model 6.")
-		.def("setMembraneModel7", &sim::AbstractMembrane<T>::setMembraneModel7, "Sets membrane model 7.")
-		.def("setMembraneModel8", &sim::AbstractMembrane<T>::setMembraneModel8, "Sets membrane model 8.")
-		.def("setMembraneModel9", &sim::AbstractMembrane<T>::setMembraneModel9, "Sets membrane model 9.")
-		.def("getMembraneResistance", &sim::AbstractMembrane<T>::getMembraneResistance, "Returns the membrane resistance.")
+	// py::class_<sim::AbstractMembrane, sim::Simulation, py::smart_holder>(m, "AbstractMembrane")
+	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
+	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+	// 			return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
+	// 		}))
+	// 	.def("setPermeabilityMembraneModel", &sim::AbstractMembrane<T>::setPermeabilityMembraneModel, "Sets the permeability membrane model.")
+	// 	.def("setPoreResistanceMembraneModel", &sim::AbstractMembrane<T>::setPoreResistanceMembraneModel, "Sets the pore resistance membrane model.")
+	// 	.def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
+	// 	.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
+	// 	.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
+	// 	.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")
+	// 	.def("setMembraneModel4", &sim::AbstractMembrane<T>::setMembraneModel4, "Sets membrane model 4.")
+	// 	.def("setMembraneModel5", &sim::AbstractMembrane<T>::setMembraneModel5, "Sets membrane model 5.")
+	// 	.def("setMembraneModel6", &sim::AbstractMembrane<T>::setMembraneModel6, "Sets membrane model 6.")
+	// 	.def("setMembraneModel7", &sim::AbstractMembrane<T>::setMembraneModel7, "Sets membrane model 7.")
+	// 	.def("setMembraneModel8", &sim::AbstractMembrane<T>::setMembraneModel8, "Sets membrane model 8.")
+	// 	.def("setMembraneModel9", &sim::AbstractMembrane<T>::setMembraneModel9, "Sets membrane model 9.")
+	// 	.def("getMembraneResistance", &sim::AbstractMembrane<T>::getMembraneResistance, "Returns the membrane resistance.")
 
-	py::class_<sim::AbstractMixing, sim::Simulation, py::smart_holder>(m, "AbstractMixing")
-		.def(py::init<std::shared_ptr<arch::Network<T>>>())
-		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::shared_ptr<sim::AbstractMixing<T>>(dynamic_cast<sim::AbstractMixing<T>*>(tmpPtr.release()));
-			}))
-		.def("setInstantaneousMixingModel", &sim::AbstractMixing<T>::setInstantaneousMixingModel, "Sets the instantaneous mixing model.")
-		.def("hasInstantaneousMixingModel", &sim::AbstractMixing<T>::hasInstantaneousMixingModel, "Returns whether an instantaneous mixing model was set.")
-		.def("setDiffusiveMixingModel", &sim::AbstractMixing<T>::setDiffusiveMixingModel, "Sets the diffusive mixing model.")
-		.def("hasDiffusiveMixingModel", &sim::AbstractMixing<T>::hasDiffusiveMixingModel, "Returns whether a diffusive mixing model was set.")
-		.def("addSpecie", &sim::AbstractMixing<T>::addSpecie, "Adds a single species to the simulator.")
-		.def("getSpecie", &sim::AbstractMixing<T>::getSpecie, "Returns a species with the given id.")
-		.def("removeSpecie", &sim::AbstractMixing<T>::removeSpecies, "Removes a species from the simulator.")
-		.def("addMixture", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
-		.def("addMixture", py::overload_cast<const std::vector<std::shared_ptr<sim::Specie<T>>>&, const std::vector<T>&>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
-		.def("getMixture", &sim::AbstractMixing<T>::getMixture, "Returns the mixture with the given id.")
-		.def("readMixtures", &sim::AbstractMixing<T>::readMixtures, "Returns a read-only list of mixtures in the simulator.")
-		.def("removeMixture", &sim::AbstractMixing<T>::removeMixture, "Removes a mixture from the simulator.")
-		.def("addMixtureInjection", py::overload_cast<int, int, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixtureId"), py::arg("edgeId"), py::arg("injectionTime"), py::arg("isPermanent")=false, 
-			"Add a mixture injection to the simulator.")
-		.def("addMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixture"), py::arg("edge"), 
-			py::arg("injectionTime"), py::arg("isPermanent")=false, "Add a mixture injection to the simulator")
-		.def("addPermanentMixtureInjection", py::overload_cast<int, int, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), "Add a permanent mixture injection to the simulator.")
-		.def("addPermanentMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), 
-			"Add a permanent mixture injection to the simulator.")
-		.def("getMixtureInjection", &sim::AbstractMixing<T>::getMixtureInjection, "Returns the mixture injection with the given id.")
-		.def("removeMixtureInjection", &sim::AbstractMixing<T>::removeMixtureInjection, "Removes the mixture injection with the given id.");
+	// py::class_<sim::AbstractMixing, sim::Simulation, py::smart_holder>(m, "AbstractMixing")
+	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
+	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+	// 			return std::shared_ptr<sim::AbstractMixing<T>>(dynamic_cast<sim::AbstractMixing<T>*>(tmpPtr.release()));
+	// 		}))
+	// 	.def("setInstantaneousMixingModel", &sim::AbstractMixing<T>::setInstantaneousMixingModel, "Sets the instantaneous mixing model.")
+	// 	.def("hasInstantaneousMixingModel", &sim::AbstractMixing<T>::hasInstantaneousMixingModel, "Returns whether an instantaneous mixing model was set.")
+	// 	.def("setDiffusiveMixingModel", &sim::AbstractMixing<T>::setDiffusiveMixingModel, "Sets the diffusive mixing model.")
+	// 	.def("hasDiffusiveMixingModel", &sim::AbstractMixing<T>::hasDiffusiveMixingModel, "Returns whether a diffusive mixing model was set.")
+	// 	.def("addSpecie", &sim::AbstractMixing<T>::addSpecie, "Adds a single species to the simulator.")
+	// 	.def("getSpecie", &sim::AbstractMixing<T>::getSpecie, "Returns a species with the given id.")
+	// 	.def("removeSpecie", &sim::AbstractMixing<T>::removeSpecies, "Removes a species from the simulator.")
+	// 	.def("addMixture", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+	// 	.def("addMixture", py::overload_cast<const std::vector<std::shared_ptr<sim::Specie<T>>>&, const std::vector<T>&>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+	// 	.def("getMixture", &sim::AbstractMixing<T>::getMixture, "Returns the mixture with the given id.")
+	// 	.def("readMixtures", &sim::AbstractMixing<T>::readMixtures, "Returns a read-only list of mixtures in the simulator.")
+	// 	.def("removeMixture", &sim::AbstractMixing<T>::removeMixture, "Removes a mixture from the simulator.")
+	// 	.def("addMixtureInjection", py::overload_cast<int, int, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixtureId"), py::arg("edgeId"), py::arg("injectionTime"), py::arg("isPermanent")=false, 
+	// 		"Add a mixture injection to the simulator.")
+	// 	.def("addMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixture"), py::arg("edge"), 
+	// 		py::arg("injectionTime"), py::arg("isPermanent")=false, "Add a mixture injection to the simulator")
+	// 	.def("addPermanentMixtureInjection", py::overload_cast<int, int, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), "Add a permanent mixture injection to the simulator.")
+	// 	.def("addPermanentMixtureInjection", py::overload_cast<const std::shared_ptr<Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), 
+	// 		"Add a permanent mixture injection to the simulator.")
+	// 	.def("getMixtureInjection", &sim::AbstractMixing<T>::getMixtureInjection, "Returns the mixture injection with the given id.")
+	// 	.def("removeMixtureInjection", &sim::AbstractMixing<T>::removeMixtureInjection, "Removes the mixture injection with the given id.");
 
-	py::class_<sim::HybridContinuous, sim::Simulation, py::smart_holder>(m, "HybridContinuous")
-		.def(py::init<std::shared_ptr<arch::Network<T>>>())
-		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
-				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
-				return std::shared_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
-			}))
-		.def("getCharacteristicLength", &sim::HybridContinuous<T>::getCharacteristicLength, "Returns the characteristic length of the LBM simulators.")
-		.def("getCharacteristicVelocity", &sim::HybridContinuous<T>::getCharacteristicVelocity, "Returns the characteristic velocity of the LBM simulators.")
-		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
-			py::arg("module"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
-		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
-			py::arg("module"), py::arg("resolution"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
-		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, T, T, T, T, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
-			py::arg("module"), py::arg("resolution"), py::arg("epsilon"), py::arg("tau"), py::arg("charPhysLength"), py::arg("charPhysVelocity"), py::arg("name")="", 
-			"Add a LBM simulator to the hybrid simulation.")
-		.def("getLbmSimulator", &sim::HybridContinuous<T>::getLbmSimulator, "Returns the LBM simulator with the given id.")
-		.def("removeLbmSimulator", &sim::HybridContinuous<T>::removeLbmSimulator, "Removes the LBM simulator from the hybrid simulation.")
-		.def("setNaiveHybridScheme", py::overload_cast<T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), "Set the naive update scheme for all simulators.")
-		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
-			"Set the naive update scheme for the given simulator.")
-		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, std::unordered_map<int, T>, std::unordered_map<int, T>, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
-			"Set the naive update scheme for the given simulator.")
-		.def("getGlobalPressureBounds", &sim::HybridContinuous<T>::getGlobalPressureBounds, "Returns the global pressure bounds in the CFD simulators.")
-		.def("getGlobalVelocityBounds", &sim::HybridContinuous<T>::getGlobalVelocityBounds, "Returns the global velocity bounds in the CFD simulators.")
-		.def("writePressurePpm", &sim::HybridContinuous<T>::writePressurePpm, "Write the pressure field in ppm format for all simulators.")
-		.def("writeVelocityPpm", &sim::HybridContinuous<T>::writeVelocityPpm, "Write the velocity field in ppm format for all simulators.");
+	// py::class_<sim::HybridContinuous, sim::Simulation, py::smart_holder>(m, "HybridContinuous")
+	// 	.def(py::init<std::shared_ptr<arch::Network<T>>>())
+	// 	.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+	// 			std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+	// 			return std::shared_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
+	// 		}))
+	// 	.def("getCharacteristicLength", &sim::HybridContinuous<T>::getCharacteristicLength, "Returns the characteristic length of the LBM simulators.")
+	// 	.def("getCharacteristicVelocity", &sim::HybridContinuous<T>::getCharacteristicVelocity, "Returns the characteristic velocity of the LBM simulators.")
+	// 	.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+	// 		py::arg("module"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+	// 	.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+	// 		py::arg("module"), py::arg("resolution"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+	// 	.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, T, T, T, T, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+	// 		py::arg("module"), py::arg("resolution"), py::arg("epsilon"), py::arg("tau"), py::arg("charPhysLength"), py::arg("charPhysVelocity"), py::arg("name")="", 
+	// 		"Add a LBM simulator to the hybrid simulation.")
+	// 	.def("getLbmSimulator", &sim::HybridContinuous<T>::getLbmSimulator, "Returns the LBM simulator with the given id.")
+	// 	.def("removeLbmSimulator", &sim::HybridContinuous<T>::removeLbmSimulator, "Removes the LBM simulator from the hybrid simulation.")
+	// 	.def("setNaiveHybridScheme", py::overload_cast<T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), "Set the naive update scheme for all simulators.")
+	// 	.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+	// 		"Set the naive update scheme for the given simulator.")
+	// 	.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<CFDSimulator<T>>&, std::unordered_map<int, T>, std::unordered_map<int, T>, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+	// 		"Set the naive update scheme for the given simulator.")
+	// 	.def("getGlobalPressureBounds", &sim::HybridContinuous<T>::getGlobalPressureBounds, "Returns the global pressure bounds in the CFD simulators.")
+	// 	.def("getGlobalVelocityBounds", &sim::HybridContinuous<T>::getGlobalVelocityBounds, "Returns the global velocity bounds in the CFD simulators.")
+	// 	.def("writePressurePpm", &sim::HybridContinuous<T>::writePressurePpm, "Write the pressure field in ppm format for all simulators.")
+	// 	.def("writeVelocityPpm", &sim::HybridContinuous<T>::writeVelocityPpm, "Write the velocity field in ppm format for all simulators.");
 		
 	#ifdef VERSION_INFO
 	m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/python/mmft/simulator/bindings.hpp
+++ b/python/mmft/simulator/bindings.hpp
@@ -1,0 +1,33 @@
+// bindings.hpp
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+// Forward declarations of all binding functions
+
+// arch bindings
+void bind_enums(py::module_& m);
+void bind_opening(py::module_& m);
+void bind_node(py::module_& m);
+void bind_edge(py::module_& m);
+void bind_channel(py::module_& m);
+void bind_pumps(py::module_& m);
+void bind_membrane(py::module_& m);
+void bind_tank(py::module_& m);
+void bind_module(py::module_& m);
+void bind_network(py::module_& m);
+
+// sim bindings
+void bind_fluid(py::module_& m);
+void bind_droplet(py::module_& m);
+void bind_specie(py::module_& m);
+void bind_mixture(py::module_& m);
+void bind_injections(py::module_& m);
+void bind_simulation(py::module_& m);
+void bind_abstractContinuous(py::module_& m);
+void bind_abstractDroplet(py::module_& m);
+void bind_abstractMembrane(py::module_& m);
+void bind_abstractMixing(py::module_& m);
+void bind_hybridContinuous(py::module_& m);

--- a/python/mmft/simulator/sim/bind_abstractContinuous.cpp
+++ b/python/mmft/simulator/sim/bind_abstractContinuous.cpp
@@ -1,7 +1,6 @@
-/**
- * @file baseSimulator.h
- */
-#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
 
 #include "simulation/entities/Droplet.h"
 #include "simulation/entities/Fluid.h"
@@ -30,9 +29,6 @@
 
 #include "simulation/simulators/CFDSim.h"
 #include "simulation/simulators/cfdHandlers/cfdSimulator.h"
-#include "simulation/simulators/cfdHandlers/olbContinuous.h"
-// #include "simulation/simulators/cfdHandlers/olbMixing.h" //** TODO: HybridMixingSimulation */
-// #include "simulation/simulators/cfdHandlers/olbOoc.h"    //** TODO: HybridOocSimulation */
 
 #include "nodalAnalysis/NodalAnalysis.h"
 
@@ -53,18 +49,23 @@
 
 #include "architecture/Network.h"
 
-//** TODO: HybridOocSimulation */
-// #include "olbProcessors/navierStokesAdvectionDiffusionCouplingPostProcessor2D.h"
-// #include "olbProcessors/saturatedFluxPostProcessor2D.h"
-// #include "olbProcessors/setFunctionalRegularizedHeatFlux.h"
-
 #include "porting/jsonPorter.h"
 #include "porting/jsonReaders.h"
 #include "porting/jsonWriters.h"
 
 #include "result/Results.h"
 
-#ifdef USE_ESSLBM
-    #include "simulation/simulators/essContinuous.h"
-    #include "simulation/simulators/essMixing.h"
-#endif
+namespace py = pybind11;
+
+using T = double;
+
+void bind_abstractContinuous(py::module_& m) {
+
+	py::class_<sim::AbstractContinuous<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractContinuous")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractContinuous<T>>(dynamic_cast<sim::AbstractContinuous<T>*>(tmpPtr.release()));
+			}));
+
+}

--- a/python/mmft/simulator/sim/bind_abstractDroplet.cpp
+++ b/python/mmft/simulator/sim/bind_abstractDroplet.cpp
@@ -1,0 +1,90 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Droplet.h"
+#include "simulation/entities/Fluid.h"
+#include "simulation/entities/Mixture.h"
+#include "simulation/entities/Specie.h"
+#include "simulation/entities/Tissue.h"
+
+#include "simulation/events/BoundaryEvent.h"
+#include "simulation/events/Event.h"
+#include "simulation/events/InjectionEvent.h"
+#include "simulation/events/MergingEvent.h"
+
+#include "simulation/operations/Injection.h"
+#include "simulation/operations/MixtureInjection.h"
+
+#include "simulation/models/MembraneModels.h"
+#include "simulation/models/MixingModels.h"
+#include "simulation/models/ResistanceModels.h"
+
+#include "simulation/simulators/Simulation.h"
+#include "simulation/simulators/AbstractContinuous.h"
+#include "simulation/simulators/AbstractDroplet.h"
+#include "simulation/simulators/AbstractMixing.h"
+#include "simulation/simulators/AbstractMembrane.h"
+#include "simulation/simulators/HybridContinuous.h"
+
+#include "simulation/simulators/CFDSim.h"
+#include "simulation/simulators/cfdHandlers/cfdSimulator.h"
+
+#include "nodalAnalysis/NodalAnalysis.h"
+
+#include "hybridDynamics/Scheme.h"
+#include "hybridDynamics/Naive.h"
+
+#include "architecture/definitions/ChannelPosition.h"
+#include "architecture/definitions/ModuleOpening.h"
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Module.h"
+#include "architecture/entities/Node.h"
+#include "architecture/entities/PressurePump.h"
+#include "architecture/entities/Tank.h"
+
+#include "architecture/Network.h"
+
+#include "porting/jsonPorter.h"
+#include "porting/jsonReaders.h"
+#include "porting/jsonWriters.h"
+
+#include "result/Results.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_abstractDroplet(py::module_& m) {
+
+	py::class_<sim::AbstractDroplet<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractDroplet")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractDroplet<T>>(dynamic_cast<sim::AbstractDroplet<T>*>(tmpPtr.release()));
+			}))
+		.def("addDroplet", py::overload_cast<int, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet of the given fluid id to the simulation.")
+		.def("addDroplet", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&, T>(&sim::AbstractDroplet<T>::addDroplet), "Adds a droplet to the simulation.")
+		.def("addMergedDroplet", py::overload_cast<int, int>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+			"Adds a droplet to the simulator, based on the ids of two existing droplets.")
+		.def("addMergedDroplet", py::overload_cast<const std::shared_ptr<sim::Droplet<T>>&, const std::shared_ptr<sim::Droplet<T>>&>(&sim::AbstractDroplet<T>::addMergedDroplet), 
+			"Adds a droplet to the simulator, based on two existing droplets.")
+		.def("getDroplet", &sim::AbstractDroplet<T>::getDroplet, "Returns the droplet with the given id.")
+		.def("getDropletAtNode", py::overload_cast<int>(&sim::AbstractDroplet<T>::getDropletAtNode, py::const_), 
+			"Checks whether a droplet is present at the node with the given id. Returns true and the droplet if one is found.")
+		.def("getDropletAtNode", py::overload_cast<const std::shared_ptr<arch::Node<T>>&>(&sim::AbstractDroplet<T>::getDropletAtNode, py::const_), 
+			"Checks whether a droplet is present at the given node. Returns true and the droplet if one is found.")
+		.def("removeDroplet", py::overload_cast<const std::shared_ptr<sim::Droplet<T>>&>(&sim::AbstractDroplet<T>::removeDroplet), "Removes a droplet from the simulation.")
+		.def("addDropletInjection", py::overload_cast<int, T, int, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+		.def("addDropletInjection", py::overload_cast<const std::shared_ptr<sim::Droplet<T>>&, T, const std::shared_ptr<arch::Channel<T>>&, T>(&sim::AbstractDroplet<T>::addDropletInjection), 
+			"Adds a droplet injection to the simulator of the given droplet at given time in the given channel and position.")
+		.def("getDropletInjection", &sim::AbstractDroplet<T>::getDropletInjection, "Returns the droplet injection with the given id.")
+		.def("removeDropletInjection", py::overload_cast<const std::shared_ptr<sim::DropletInjection<T>>&>(&sim::AbstractDroplet<T>::removeDropletInjection), 
+			"Removes the droplet injection from the simulation.");
+
+}

--- a/python/mmft/simulator/sim/bind_abstractMembrane.cpp
+++ b/python/mmft/simulator/sim/bind_abstractMembrane.cpp
@@ -55,50 +55,28 @@
 
 #include "result/Results.h"
 
-#include <baseSimulator.hh>
-
-#include "bindings.hpp"
-
-#define STRINGIFY(x) #x
-#define MACRO_STRINGIFY(x) STRINGIFY(x)
+namespace py = pybind11;
 
 using T = double;
 
-namespace py = pybind11;
-using namespace pybind11::literals;
+void bind_abstractMembrane(py::module_& m) {
 
-PYBIND11_MODULE(pysimulator, m) {
-	m.doc() = "Python binding for the MMFT-Simulator.";
+	py::class_<sim::AbstractMembrane<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractMembrane")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractMembrane<T>>(dynamic_cast<sim::AbstractMembrane<T>*>(tmpPtr.release()));
+			}))
+		.def("setMembraneModel0", &sim::AbstractMembrane<T>::setMembraneModel0, "Sets membrane model 0.")
+		.def("setMembraneModel1", &sim::AbstractMembrane<T>::setMembraneModel1, "Sets membrane model 1.")
+		.def("setMembraneModel2", &sim::AbstractMembrane<T>::setMembraneModel2, "Sets membrane model 2.")
+		.def("setMembraneModel3", &sim::AbstractMembrane<T>::setMembraneModel3, "Sets membrane model 3.")
+		.def("setMembraneModel4", &sim::AbstractMembrane<T>::setMembraneModel4, "Sets membrane model 4.")
+		.def("setMembraneModel5", &sim::AbstractMembrane<T>::setMembraneModel5, "Sets membrane model 5.")
+		.def("setMembraneModel6", &sim::AbstractMembrane<T>::setMembraneModel6, "Sets membrane model 6.")
+		.def("setMembraneModel7", &sim::AbstractMembrane<T>::setMembraneModel7, "Sets membrane model 7.")
+		.def("setMembraneModel8", &sim::AbstractMembrane<T>::setMembraneModel8, "Sets membrane model 8.")
+		.def("setMembraneModel9", &sim::AbstractMembrane<T>::setMembraneModel9, "Sets membrane model 9.")
+		.def("getMembraneResistance", &sim::AbstractMembrane<T>::getMembraneResistance, "Returns the membrane resistance.");
 
-	// Architecture bindings
-	bind_enums(m);
-	bind_opening(m);
-	bind_node(m);
-	bind_edge(m);
-	bind_channel(m);
-	bind_pumps(m);
-	bind_membrane(m);
-	bind_tank(m);
-	bind_module(m);
-	bind_network(m);
-
-	// Simulator bindings
-	bind_fluid(m);
-	bind_droplet(m);
-	bind_specie(m);
-	bind_mixture(m);
-	bind_injections(m);
-	bind_cfdSimulators(m);
-	bind_simulation(m);
-	bind_abstractContinuous(m);
-	bind_abstractDroplet(m);
-	bind_abstractMembrane(m);
-	bind_abstractMixing(m);
-	bind_hybridContinuous(m);
-		
-	#ifdef VERSION_INFO
-	m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
-	#else
-	m.attr("__version__") = "dev";
-	#endif
 }

--- a/python/mmft/simulator/sim/bind_abstractMixing.cpp
+++ b/python/mmft/simulator/sim/bind_abstractMixing.cpp
@@ -1,0 +1,93 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Droplet.h"
+#include "simulation/entities/Fluid.h"
+#include "simulation/entities/Mixture.h"
+#include "simulation/entities/Specie.h"
+#include "simulation/entities/Tissue.h"
+
+#include "simulation/events/BoundaryEvent.h"
+#include "simulation/events/Event.h"
+#include "simulation/events/InjectionEvent.h"
+#include "simulation/events/MergingEvent.h"
+
+#include "simulation/operations/Injection.h"
+#include "simulation/operations/MixtureInjection.h"
+
+#include "simulation/models/MembraneModels.h"
+#include "simulation/models/MixingModels.h"
+#include "simulation/models/ResistanceModels.h"
+
+#include "simulation/simulators/Simulation.h"
+#include "simulation/simulators/AbstractContinuous.h"
+#include "simulation/simulators/AbstractDroplet.h"
+#include "simulation/simulators/AbstractMixing.h"
+#include "simulation/simulators/AbstractMembrane.h"
+#include "simulation/simulators/HybridContinuous.h"
+
+#include "simulation/simulators/CFDSim.h"
+#include "simulation/simulators/cfdHandlers/cfdSimulator.h"
+
+#include "nodalAnalysis/NodalAnalysis.h"
+
+#include "hybridDynamics/Scheme.h"
+#include "hybridDynamics/Naive.h"
+
+#include "architecture/definitions/ChannelPosition.h"
+#include "architecture/definitions/ModuleOpening.h"
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Module.h"
+#include "architecture/entities/Node.h"
+#include "architecture/entities/PressurePump.h"
+#include "architecture/entities/Tank.h"
+
+#include "architecture/Network.h"
+
+#include "porting/jsonPorter.h"
+#include "porting/jsonReaders.h"
+#include "porting/jsonWriters.h"
+
+#include "result/Results.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_abstractMixing(py::module_& m) {
+
+	py::class_<sim::AbstractMixing<T>, sim::Simulation<T>, py::smart_holder>(m, "AbstractMixing")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::AbstractMixing<T>>(dynamic_cast<sim::AbstractMixing<T>*>(tmpPtr.release()));
+			}))
+		.def("setInstantaneousMixingModel", &sim::AbstractMixing<T>::setInstantaneousMixingModel, "Sets the instantaneous mixing model.")
+		.def("hasInstantaneousMixingModel", &sim::AbstractMixing<T>::hasInstantaneousMixingModel, "Returns whether an instantaneous mixing model was set.")
+		.def("setDiffusiveMixingModel", &sim::AbstractMixing<T>::setDiffusiveMixingModel, "Sets the diffusive mixing model.")
+		.def("hasDiffusiveMixingModel", &sim::AbstractMixing<T>::hasDiffusiveMixingModel, "Returns whether a diffusive mixing model was set.")
+		.def("addSpecie", &sim::AbstractMixing<T>::addSpecie, "Adds a single species to the simulator.")
+		.def("getSpecie", &sim::AbstractMixing<T>::getSpecie, "Returns a species with the given id.")
+		.def("removeSpecie", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::AbstractMixing<T>::removeSpecie), "Removes a species from the simulator.")
+		.def("addMixture", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&, T>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+		.def("addMixture", py::overload_cast<const std::vector<std::shared_ptr<sim::Specie<T>>>&, const std::vector<T>&>(&sim::AbstractMixing<T>::addMixture), "Adds a mixture to the simulator.")
+		.def("getMixture", &sim::AbstractMixing<T>::getMixture, "Returns the mixture with the given id.")
+		.def("readMixtures", &sim::AbstractMixing<T>::readMixtures, "Returns a read-only list of mixtures in the simulator.")
+		.def("removeMixture", py::overload_cast<const std::shared_ptr<sim::Mixture<T>>&>(&sim::AbstractMixing<T>::removeMixture), "Removes a mixture from the simulator.")
+		.def("addMixtureInjection", py::overload_cast<int, int, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixtureId"), py::arg("edgeId"), py::arg("injectionTime"), py::arg("isPermanent")=false, 
+			"Add a mixture injection to the simulator.")
+		.def("addMixtureInjection", py::overload_cast<const std::shared_ptr<sim::Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T, bool>(&sim::AbstractMixing<T>::addMixtureInjection), py::arg("mixture"), py::arg("edge"), 
+			py::arg("injectionTime"), py::arg("isPermanent")=false, "Add a mixture injection to the simulator")
+		.def("addPermanentMixtureInjection", py::overload_cast<int, int, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), "Add a permanent mixture injection to the simulator.")
+		.def("addPermanentMixtureInjection", py::overload_cast<const std::shared_ptr<sim::Mixture<T>>&, const std::shared_ptr<arch::Edge<T>>&, T>(&sim::AbstractMixing<T>::addPermanentMixtureInjection), 
+			"Add a permanent mixture injection to the simulator.")
+		.def("getMixtureInjection", &sim::AbstractMixing<T>::getMixtureInjection, "Returns the mixture injection with the given id.")
+		.def("removeMixtureInjection", py::overload_cast<const std::shared_ptr<sim::MixtureInjection<T>>&>(&sim::AbstractMixing<T>::removeMixtureInjection), 
+			"Removes the mixture injection with the given id.");
+
+}

--- a/python/mmft/simulator/sim/bind_droplet.cpp
+++ b/python/mmft/simulator/sim/bind_droplet.cpp
@@ -1,0 +1,31 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/Channel.h"
+#include "architecture/definitions/ChannelPosition.h"
+#include "simulation/entities/Droplet.h"
+#include "simulation/entities/Fluid.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_droplet(py::module_& m) {
+
+	py::class_<sim::Droplet<T>, py::smart_holder>(m, "Droplet")
+		.def("getId", &sim::Droplet<T>::getId, "Returns the id of the droplet.")
+		.def("getName", &sim::Droplet<T>::getName, "Returns the name of the droplet.")
+		.def("setName", &sim::Droplet<T>::setName, "Sets the name of the droplet.")
+		.def("getVolume", &sim::Droplet<T>::getVolume, "Returns the volume of the droplet [m^3].")
+		.def("setVolume", &sim::Droplet<T>::setVolume, "Sets the volume of the droplet [m^3].")
+		.def("readFluid", &sim::Droplet<T>::readFluid, py::return_value_policy::reference, 
+			"Returns a read-only reference to the Fluid that constitutes the droplet.")
+		.def("setFluid", &sim::Droplet<T>::setFluid, "Sets the fluid that the droplet consists of.")
+		.def("readBoundaries", &sim::Droplet<T>::readBoundaries, py::return_value_policy::reference, 
+			"Returns a read-only list of the droplet boundaries.")
+		.def("readFullyOccupiedChannels", &sim::Droplet<T>::readFullyOccupiedChannels, py::return_value_policy::reference, 
+			"Returns a read-only list of the channels that the droplet occupies fully.");
+
+}

--- a/python/mmft/simulator/sim/bind_fluid.cpp
+++ b/python/mmft/simulator/sim/bind_fluid.cpp
@@ -1,7 +1,6 @@
-/**
- * @file baseSimulator.h
- */
-#pragma once
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
 
 #include "simulation/entities/Droplet.h"
 #include "simulation/entities/Fluid.h"
@@ -30,9 +29,6 @@
 
 #include "simulation/simulators/CFDSim.h"
 #include "simulation/simulators/cfdHandlers/cfdSimulator.h"
-#include "simulation/simulators/cfdHandlers/olbContinuous.h"
-// #include "simulation/simulators/cfdHandlers/olbMixing.h" //** TODO: HybridMixingSimulation */
-// #include "simulation/simulators/cfdHandlers/olbOoc.h"    //** TODO: HybridOocSimulation */
 
 #include "nodalAnalysis/NodalAnalysis.h"
 
@@ -53,18 +49,25 @@
 
 #include "architecture/Network.h"
 
-//** TODO: HybridOocSimulation */
-// #include "olbProcessors/navierStokesAdvectionDiffusionCouplingPostProcessor2D.h"
-// #include "olbProcessors/saturatedFluxPostProcessor2D.h"
-// #include "olbProcessors/setFunctionalRegularizedHeatFlux.h"
-
 #include "porting/jsonPorter.h"
 #include "porting/jsonReaders.h"
 #include "porting/jsonWriters.h"
 
 #include "result/Results.h"
 
-#ifdef USE_ESSLBM
-    #include "simulation/simulators/essContinuous.h"
-    #include "simulation/simulators/essMixing.h"
-#endif
+namespace py = pybind11;
+
+using T = double;
+
+void bind_fluid(py::module_& m) {
+
+	py::class_<sim::Fluid<T>, py::smart_holder>(m, "Fluid")
+		.def("getId", &sim::Fluid<T>::getId, "Returns the id of the fluid.")
+		.def("setName", &sim::Fluid<T>::setName, "Sets the name of the fluid.")
+		.def("getName", &sim::Fluid<T>::getName, "Returns the name of the fluid.")
+		.def("setViscosity", &sim::Fluid<T>::setViscosity, "Sets the viscosity of the fluid.")
+		.def("getViscosity", &sim::Fluid<T>::getViscosity, "Returns the viscosity of the fluid.")
+		.def("setDensity", &sim::Fluid<T>::setDensity, "Sets the density of the fluid.")
+		.def("getDensity", &sim::Fluid<T>::getDensity, "Returns the density of the fluid.");
+
+}

--- a/python/mmft/simulator/sim/bind_hybridContinuous.cpp
+++ b/python/mmft/simulator/sim/bind_hybridContinuous.cpp
@@ -1,0 +1,122 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Droplet.h"
+#include "simulation/entities/Fluid.h"
+#include "simulation/entities/Mixture.h"
+#include "simulation/entities/Specie.h"
+#include "simulation/entities/Tissue.h"
+
+#include "simulation/events/BoundaryEvent.h"
+#include "simulation/events/Event.h"
+#include "simulation/events/InjectionEvent.h"
+#include "simulation/events/MergingEvent.h"
+
+#include "simulation/operations/Injection.h"
+#include "simulation/operations/MixtureInjection.h"
+
+#include "simulation/models/MembraneModels.h"
+#include "simulation/models/MixingModels.h"
+#include "simulation/models/ResistanceModels.h"
+
+#include "simulation/simulators/Simulation.h"
+#include "simulation/simulators/AbstractContinuous.h"
+#include "simulation/simulators/AbstractDroplet.h"
+#include "simulation/simulators/AbstractMixing.h"
+#include "simulation/simulators/AbstractMembrane.h"
+#include "simulation/simulators/HybridContinuous.h"
+
+#include "simulation/simulators/CFDSim.h"
+#include "simulation/simulators/cfdHandlers/cfdSimulator.h"
+#include "simulation/simulators/cfdHandlers/olbContinuous.h"
+
+#include "nodalAnalysis/NodalAnalysis.h"
+
+#include "hybridDynamics/Scheme.h"
+#include "hybridDynamics/Naive.h"
+
+#include "architecture/definitions/ChannelPosition.h"
+#include "architecture/definitions/ModuleOpening.h"
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Module.h"
+#include "architecture/entities/Node.h"
+#include "architecture/entities/PressurePump.h"
+#include "architecture/entities/Tank.h"
+
+#include "architecture/Network.h"
+
+#include "porting/jsonPorter.h"
+#include "porting/jsonReaders.h"
+#include "porting/jsonWriters.h"
+
+#include "result/Results.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_hybridContinuous(py::module_& m) {
+
+	py::class_<sim::HybridContinuous<T>, sim::Simulation<T>, py::smart_holder>(m, "HybridContinuous")
+		.def(py::init<std::shared_ptr<arch::Network<T>>>())
+		.def(py::init([](std::string file, std::shared_ptr<arch::Network<T>> network){
+				std::unique_ptr<sim::Simulation<T>> tmpPtr = porting::simulationFromJSON<T>(file, network);
+				return std::shared_ptr<sim::HybridContinuous<T>>(dynamic_cast<sim::HybridContinuous<T>*>(tmpPtr.release()));
+			}))
+		.def("getCharacteristicLength", &sim::HybridContinuous<T>::getCharacteristicLength, "Returns the characteristic length of the LBM simulators.")
+		.def("getCharacteristicVelocity", &sim::HybridContinuous<T>::getCharacteristicVelocity, "Returns the characteristic velocity of the LBM simulators.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("resolution"), py::arg("name")="", "Add a LBM simulator to the hybrid simulation.")
+		.def("addLbmSimulator", py::overload_cast<std::shared_ptr<arch::CfdModule<T>> const, size_t, T, T, T, T, std::string>(&sim::HybridContinuous<T>::addLbmSimulator),
+			py::arg("module"), py::arg("resolution"), py::arg("epsilon"), py::arg("tau"), py::arg("charPhysLength"), py::arg("charPhysVelocity"), py::arg("name")="", 
+			"Add a LBM simulator to the hybrid simulation.")
+		.def("getLbmSimulator", &sim::HybridContinuous<T>::getLbmSimulator, "Returns the LBM simulator with the given id.")
+		.def("removeLbmSimulator", &sim::HybridContinuous<T>::removeLbmSimulator, "Removes the LBM simulator from the hybrid simulation.")
+		.def("setNaiveHybridScheme", py::overload_cast<T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), "Set the naive update scheme for all simulators.")
+		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<sim::CFDSimulator<T>>&, T, T, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+			"Set the naive update scheme for the given simulator.")
+		.def("setNaiveHybridScheme", py::overload_cast<const std::shared_ptr<sim::CFDSimulator<T>>&, std::unordered_map<int, T>, std::unordered_map<int, T>, int>(&sim::HybridContinuous<T>::setNaiveHybridScheme), 
+			"Set the naive update scheme for the given simulator.")
+		.def("getGlobalPressureBounds", &sim::HybridContinuous<T>::getGlobalPressureBounds, "Returns the global pressure bounds in the CFD simulators.")
+		.def("getGlobalVelocityBounds", &sim::HybridContinuous<T>::getGlobalVelocityBounds, "Returns the global velocity bounds in the CFD simulators.")
+		.def("writePressurePpm", &sim::HybridContinuous<T>::writePressurePpm, "Write the pressure field in ppm format for all simulators.")
+		.def("writeVelocityPpm", &sim::HybridContinuous<T>::writeVelocityPpm, "Write the velocity field in ppm format for all simulators.");
+
+}
+
+void bind_cfdSimulators(py::module_& m) {
+
+	py::class_<sim::CFDSimulator<T>, py::smart_holder>(m, "CFDSimulator")
+		.def("getId", &sim::CFDSimulator<T>::getId, "Returns the id of the CFD simulator.")
+		.def("getModule", &sim::CFDSimulator<T>::getModule, "Returns the module on which the simulator acts.")
+		.def("getGroundNodes", &sim::CFDSimulator<T>::getGroundNodes, "Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.")
+		.def("setVtkFolder", &sim::CFDSimulator<T>::setVtkFolder, "Sets the folder in which the vtk output should be stored.")
+		.def("getVtkFile", &sim::CFDSimulator<T>::getVtkFile, "Returns the location where the last vtk file was created.")
+		.def("getAlpha", &sim::CFDSimulator<T>::getAlpha, "Returns the relaxation factor for pressure updates.")
+		.def("getBeta", &sim::CFDSimulator<T>::getBeta, "Returns the relaxation factor for flow rate updates.")
+		.def("writeVtk", &sim::CFDSimulator<T>::writeVTK, "Write a vtk file with the current CFD simulation results.")
+		.def("writePressurePpm", &sim::CFDSimulator<T>::writePressurePpm, "Write the ppm image of the pressure results.")
+		.def("writeVelocityPpm", &sim::CFDSimulator<T>::writeVelocityPpm, "Write the ppm image of the velocity results.")
+		.def("getPressureBounds", &sim::CFDSimulator<T>::getPressureBounds, "Returns the pressre bounds of the simulator.")
+		.def("getVelocityBounds", &sim::CFDSimulator<T>::getVelocityBounds, "Returns the velocity bounds of the simulator.");
+
+	py::class_<sim::lbmSimulator<T>, sim::CFDSimulator<T>, py::smart_holder>(m, "lbmSimulator")
+		.def("getCharPhysLength", &sim::lbmSimulator<T>::getCharPhysLength, "Returns the characteristic physical length of the lbm simulator.")
+		.def("getCharPhysVelocity", &sim::lbmSimulator<T>::getCharPhysVelocity, "Returns the characteristic physical velocity of the lbm simulator.")
+		.def("getResolution", &sim::lbmSimulator<T>::getResolution, "Returns the resolution of the lbm simulator.")
+		.def("setResolution", &sim::lbmSimulator<T>::setResolution, "Sets the resolution of the lbm simulator.")
+		.def("getEpsilon", &sim::lbmSimulator<T>::getEpsilon, "Returns the epsilon for the simulator.")
+		.def("setEpsilon", &sim::lbmSimulator<T>::setEpsilon, "Sets the epsilon for the simulator.")
+		.def("getTau", &sim::lbmSimulator<T>::getTau, "Returns the relaxation time of the simulator.")
+		.def("setTau", &sim::lbmSimulator<T>::setTau, "Sets the relaxation time of the simulator.")
+		.def("getStepIter", &sim::lbmSimulator<T>::getStepIter, "Returns the number of steps used for the value tracer (default = 1000).")
+		.def("hasConverged", &sim::lbmSimulator<T>::hasConverged, "Returns whether the simulator has converged or not.");
+
+}

--- a/python/mmft/simulator/sim/bind_injections.cpp
+++ b/python/mmft/simulator/sim/bind_injections.cpp
@@ -1,0 +1,49 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Droplet.h"
+#include "simulation/entities/Fluid.h"
+#include "simulation/entities/Mixture.h"
+#include "simulation/entities/Specie.h"
+#include "simulation/entities/Tissue.h"
+
+#include "simulation/events/BoundaryEvent.h"
+#include "simulation/events/Event.h"
+#include "simulation/events/InjectionEvent.h"
+#include "simulation/events/MergingEvent.h"
+
+#include "simulation/operations/Injection.h"
+#include "simulation/operations/MixtureInjection.h"
+
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/Channel.h"
+#include "architecture/definitions/ChannelPosition.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_injections(py::module_& m) {
+
+	py::class_<sim::DropletInjection<T>, py::smart_holder>(m, "DropletInjection")
+		.def("getId", &sim::DropletInjection<T>::getId, "Returns the id of the droplet injection.")
+		.def("getName", &sim::DropletInjection<T>::getName, "Returns the name of the droplet injection.")
+		.def("setName", &sim::DropletInjection<T>::setName, "Sets the name of the droplet inkection.")
+		.def("getInjectionTime", &sim::DropletInjection<T>::getInjectionTime, "Returns the time at which the droplet is injected [s].")
+		.def("setInjectionTime", &sim::DropletInjection<T>::setInjectionTime, "Sets the time at which the droplet should be injected [s].")
+		.def("getInjectionPosition", &sim::DropletInjection<T>::getInjectionPosition, "Returns the relative channel position at which the droplet is injected [0.0-1.0].")
+		.def("setInjectionPosition", &sim::DropletInjection<T>::setInjectionPosition, "Sets the relative channel position at which the droplet is injected [0.0-1.0].")
+		.def("getInjectionChannel", &sim::DropletInjection<T>::getInjectionPosition, "Returns the channel into which the droplet is injected.")
+		.def("setInjectionChannel", &sim::DropletInjection<T>::setInjectionPosition, "Sets the channel into which the droplet is injected.");
+
+	py::class_<sim::MixtureInjection<T>, py::smart_holder>(m, "MixtureInjection")
+		.def("getId", &sim::MixtureInjection<T>::getId, "Returns the id of the mixture injection.")
+		.def("getName", &sim::MixtureInjection<T>::getName, "Returns the name of the mixture injection.")
+		.def("setName", &sim::MixtureInjection<T>::setName, "Sets the name of the mixture inkection.")
+		.def("getInjectionTime", &sim::MixtureInjection<T>::getInjectionTime, "Returns the time at which the mixture is injected [s].")
+		.def("setInjectionTime", &sim::MixtureInjection<T>::setInjectionTime, "Sets the time at which the mixture should be injected [s].")
+		.def("getInjectionChannel", &sim::MixtureInjection<T>::getInjectionChannel, "Returns the channel into which the mixture is injected.")
+		.def("setInjectionChannel", &sim::MixtureInjection<T>::setInjectionChannel, "Sets the channel into which the mixture is injected.");
+
+}

--- a/python/mmft/simulator/sim/bind_mixture.cpp
+++ b/python/mmft/simulator/sim/bind_mixture.cpp
@@ -1,0 +1,40 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Fluid.h"
+#include "simulation/entities/Mixture.h"
+#include "simulation/entities/Specie.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_mixture(py::module_& m) {
+
+	py::class_<sim::Mixture<T>, py::smart_holder>(m, "Mixture")
+		.def(py::self == py::self)
+		.def("getId", &sim::Mixture<T>::getId, "Returns the id of the mixture.")
+		.def("getName", &sim::Mixture<T>::getName, "Returns the name of the mixture.")
+		.def("setName", &sim::Mixture<T>::setName, "Sets the name of the mixture.")
+		.def("addSpecie", &sim::Mixture<T>::addSpecie, "Adds a specie with a given concentration to this mixture.")
+		.def("getSpecie", &sim::Mixture<T>::getSpecie, "Returns the specie with the given id from this mixture, together with the concentration.")
+		.def("getSpecies", &sim::Mixture<T>::getSpecie, "Returns the specie from this mixture, with the given id.")
+		.def("getSpecieConcentrations", &sim::Mixture<T>::getSpecieConcentrations, "Returns a map of the specie concentrations.")
+		.def("getConcentrationOfSpecie", py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::Mixture<T>::getConcentrationOfSpecie, py::const_), 
+			"Returns the concentration of a specie [g/m^3].")
+		.def("getSpecieDistributions", &sim::Mixture<T>::getSpecieDistributions, "Returns the concentration distributions of all species if it's not a constant value [g/m^3].")
+		.def("setSpecieConcentration", &sim::Mixture<T>::setSpecieConcentration, "Sets the concentration of a specie [g/m^3].")
+		.def("getSpecieCount", &sim::Mixture<T>::getSpecieCount, "Returns the number of species listed in the mixture.")
+		.def("removeSpecie", &sim::Mixture<T>::removeSpecie, "Removes a specie from the mixture.")
+		.def("getDensity", &sim::Mixture<T>::getDensity, "Returns the density of the mixture [kg/m^3].")
+		.def("getViscosity", &sim::Mixture<T>::getViscosity, "Returns the viscosity of the mixture [Pa s].")
+		.def("getLargestMolecularSize", &sim::Mixture<T>::getLargestMolecularSize, "Returns the largest molecular size of the species in the mixture [m^3].");
+
+	py::class_<sim::DiffusiveMixture<T>, sim::Mixture<T>, py::smart_holder>(m, "DiffusiveMixture")
+		.def("setResolution", &sim::DiffusiveMixture<T>::setResolution, "Sets the spectral resolution of the distribution function.")
+		.def("getResolution", &sim::DiffusiveMixture<T>::getResolution, "Returns the spectral resolution of the distribution function.")
+		.def("getDistributionOfSpecie",  py::overload_cast<const std::shared_ptr<sim::Specie<T>>&>(&sim::DiffusiveMixture<T>::getDistributionOfSpecie, py::const_), 
+			"Returns the concentration distribution of a species if it's not a constant value [g/m^3].");
+
+}

--- a/python/mmft/simulator/sim/bind_simulation.cpp
+++ b/python/mmft/simulator/sim/bind_simulation.cpp
@@ -1,0 +1,93 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Droplet.h"
+#include "simulation/entities/Fluid.h"
+#include "simulation/entities/Mixture.h"
+#include "simulation/entities/Specie.h"
+#include "simulation/entities/Tissue.h"
+
+#include "simulation/events/BoundaryEvent.h"
+#include "simulation/events/Event.h"
+#include "simulation/events/InjectionEvent.h"
+#include "simulation/events/MergingEvent.h"
+
+#include "simulation/operations/Injection.h"
+#include "simulation/operations/MixtureInjection.h"
+
+#include "simulation/models/MembraneModels.h"
+#include "simulation/models/MixingModels.h"
+#include "simulation/models/ResistanceModels.h"
+
+#include "simulation/simulators/Simulation.h"
+#include "simulation/simulators/AbstractContinuous.h"
+#include "simulation/simulators/AbstractDroplet.h"
+#include "simulation/simulators/AbstractMixing.h"
+#include "simulation/simulators/AbstractMembrane.h"
+#include "simulation/simulators/HybridContinuous.h"
+
+#include "simulation/simulators/CFDSim.h"
+#include "simulation/simulators/cfdHandlers/cfdSimulator.h"
+
+#include "nodalAnalysis/NodalAnalysis.h"
+
+#include "hybridDynamics/Scheme.h"
+#include "hybridDynamics/Naive.h"
+
+#include "architecture/definitions/ChannelPosition.h"
+#include "architecture/definitions/ModuleOpening.h"
+
+#include "architecture/entities/Channel.h"
+#include "architecture/entities/Edge.h"
+#include "architecture/entities/FlowRatePump.h"
+#include "architecture/entities/Membrane.h"
+#include "architecture/entities/Module.h"
+#include "architecture/entities/Node.h"
+#include "architecture/entities/PressurePump.h"
+#include "architecture/entities/Tank.h"
+
+#include "architecture/Network.h"
+
+#include "porting/jsonPorter.h"
+#include "porting/jsonReaders.h"
+#include "porting/jsonWriters.h"
+
+#include "result/Results.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_simulation(py::module_& m) {
+
+	py::class_<sim::Simulation<T>, py::smart_holder>(m, "Simulation")
+		.def("getPlatform", &sim::Simulation<T>::getPlatform, "Returns the platform of the simulation.")
+		.def("getType", &sim::Simulation<T>::getType, "Returns the type of simulation [Abstract, Hybrid CFD].")
+		.def("getNetwork", &sim::Simulation<T>::getNetwork, "Returns the network on which the simulation is conducted.")
+		.def("setNetwork", &sim::Simulation<T>::setNetwork, "Sets the network on which the simulation is conducted.")
+		.def("set1DResistanceModel", &sim::Simulation<T>::set1DResistanceModel, "Sets the resistance model for abstract simulation to the 1D resistance model.")
+		.def("setPoiseuilleResistanceModel", &sim::Simulation<T>::setPoiseuilleResistanceModel, "Sets the resistance model for abstract simulation components to the poiseuille resistance model.")
+		.def("addFluid", &sim::Simulation<T>::addFluid, "Adds a fluid to the simulation.")
+		.def("addMixedFluid", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&, T, const std::shared_ptr<sim::Fluid<T>>&, T>(&sim::Simulation<T>::addMixedFluid), 
+			"Creates and adds a new fluid from two existing fluids.")
+		.def("getFluid", &sim::Simulation<T>::getFluid, "Returns the fluid for the given id.")
+		.def("readFluids", &sim::Simulation<T>::readFluids, py::return_value_policy::reference, "Returns a read-only list of fluids.")
+		.def("removeFluid", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::removeFluid), 
+			"Removes a fluid from the simulation.")
+		.def("getFixtureId", &sim::Simulation<T>::getFixtureId, "Returns the fixture id.")
+		.def("setFixtureId", &sim::Simulation<T>::setFixtureId, "Sets the fixture id.")
+		.def("getContinuousPhase", &sim::Simulation<T>::getContinuousPhase, "Returns the continuous phase of the simulation.")
+		.def("setContinuousPhase", py::overload_cast<int>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the fluid with the given id.")
+		.def("setContinuousPhase", py::overload_cast<const std::shared_ptr<sim::Fluid<T>>&>(&sim::Simulation<T>::setContinuousPhase), "Set the continuous phase of the simulation to the given fluid.")
+		.def("getCurrentIteration", &sim::Simulation<T>::getCurrentIteration, "Returns the current iteration number.")
+		.def("getMaxIterations", &sim::Simulation<T>::getMaxIterations, "Returns the maximum number of allowed iterations. When reached the simulation ends.")
+		.def("setWriteInterval", &sim::Simulation<T>::setWriteInterval, "Set the iterations interval at which the stat is saved in the results.")
+		.def("getTMax", &sim::Simulation<T>::getTMax, "Returns the maximum allowed physical time. When reached the simulation ends.")
+		.def("setMaxEndTime", &sim::Simulation<T>::setMaxEndTime, "Set the maximal physical time after which the simulation ends.")
+		// TODO today
+		// .def("getResults", &sim::Simulation<T>::getResults, py::return_value_policy::reference, "Returns the results of the simulation.")
+		.def("printResults", &sim::Simulation<T>::printResults, "Prints the results of the simulation to the console.")
+		.def("simulate", &sim::Simulation<T>::simulate, "Conducts the simulation.");
+
+}

--- a/python/mmft/simulator/sim/bind_specie.cpp
+++ b/python/mmft/simulator/sim/bind_specie.cpp
@@ -1,0 +1,22 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "simulation/entities/Specie.h"
+
+namespace py = pybind11;
+
+using T = double;
+
+void bind_specie(py::module_& m) {
+
+	py::class_<sim::Specie<T>, py::smart_holder>(m, "Specie")
+		.def("getId", &sim::Specie<T>::getId, "Returns the id of the specie.")
+		.def("setName", &sim::Specie<T>::setName, "Sets the name of the specie.")
+		.def("getName", &sim::Specie<T>::getName, "Returns the name of the specie.")
+		.def("setDiffusivity", &sim::Specie<T>::setDiffusivity, "Sets the diffusion coefficient of this species.")
+		.def("getDiffusivity", &sim::Specie<T>::getDiffusivity, "Returns the diffusion coefficient of this species.")
+		.def("setSatConc", &sim::Specie<T>::setSatConc, "Sets the saturation concentration of this specie.")
+		.def("getSatConc", &sim::Specie<T>::getSatConc, "Returns the saturation concentration of this specie.");
+
+}

--- a/src/architecture/Network.h
+++ b/src/architecture/Network.h
@@ -650,7 +650,7 @@ public:
      * @param[in] module Pointer to the module that should be removed.
      * @throws logic_error if the module is not found in the network.
      */
-    void removeModule(const std::shared_ptr<CfdModule<T>>& module);
+    void removeModule(const std::shared_ptr<Module<T>>& module);
 
     //=====================================================================================
     //====================================== Membrane =====================================

--- a/src/architecture/Network.h
+++ b/src/architecture/Network.h
@@ -317,7 +317,7 @@ public:
      * @brief Specifies a node as sink.
      * @param[in] node Pointer to the node that is a sink.
      */
-    void setSink(std::shared_ptr<Node<T>> node) const { setSink(node->getId()); }
+    void setSink(std::shared_ptr<Node<T>> node) { setSink(node->getId()); }
 
     /**
      * @brief Checks and returns if a node is a sink.
@@ -343,7 +343,7 @@ public:
      * @brief Sets a node as the ground node, i.e., this node has a pressure value of 0 and acts as a reference node for all other nodes.
      * @param[in] node Pointer to the node that should be the ground node of the network.
      */
-    void setGround(std::shared_ptr<Node<T>> node) const { setGround(node->getId()); }
+    void setGround(std::shared_ptr<Node<T>> node) { setGround(node->getId()); }
 
     /**
      * @brief Checks and returns if a node is a ground node.
@@ -362,12 +362,12 @@ public:
     /**
      * @brief Calculate the distance between the two given nodes
      */
-    [[nodiscard]] T calculateNodeDistance(size_t nodeAId, size_t nodeBId);
+    [[nodiscard]] T calculateNodeDistance(size_t nodeAId, size_t nodeBId) const;
 
     /**
      * @brief Calculate the distance between the two given nodes
      */
-    [[nodiscard]] T calculateNodeDistance(std::shared_ptr<Node<T>> nodeAId, std::shared_ptr<Node<T>> nodeBId) { return calculateNodeDistance(nodeAId->getId(), nodeBId->getId()); }
+    [[nodiscard]] T calculateNodeDistance(std::shared_ptr<Node<T>> nodeAId, std::shared_ptr<Node<T>> nodeBId) const { return calculateNodeDistance(nodeAId->getId(), nodeBId->getId()); }
 
     /**
      * @brief Removes a node from the network.
@@ -429,7 +429,7 @@ public:
      */
     [[maybe_unused]] std::shared_ptr<RectangularChannel<T>> addRectangularChannel(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB, T height, T width, T length, ChannelType type) 
     { 
-        addRectangularChannel(nodeA->getId(), nodeB->getId(), height, width, length, type); 
+        return addRectangularChannel(nodeA->getId(), nodeB->getId(), height, width, length, type); 
     }
 
     /**
@@ -454,7 +454,7 @@ public:
      */
     [[maybe_unused]] std::shared_ptr<RectangularChannel<T>> addRectangularChannel(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB, T height, T width, ChannelType type) 
     { 
-        addRectangularChannel(nodeA->getId(), nodeB->getId(), height, width, type); 
+        return addRectangularChannel(nodeA->getId(), nodeB->getId(), height, width, type); 
     }
 
     /**
@@ -477,7 +477,7 @@ public:
      */
     [[maybe_unused]] std::shared_ptr<RectangularChannel<T>> addRectangularChannel(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB, T resistance, ChannelType type) 
     { 
-        addRectangularChannel(nodeA->getId(), nodeB->getId(), resistance, type); 
+        return addRectangularChannel(nodeA->getId(), nodeB->getId(), resistance, type); 
     }
 
     /**
@@ -686,7 +686,7 @@ public:
      * @param membraneId Id of the membrane.
      * @return Pointer to the membrane with this id.
      */
-    [[nodiscard]] std::shared_ptr<Membrane<T>> getMembrane(size_t membraneId);
+    [[nodiscard]] std::shared_ptr<Membrane<T>> getMembrane(size_t membraneId) const;
     
     /**
      * @brief Get the membrane that is connected to both specified nodes.
@@ -694,7 +694,7 @@ public:
      * @param nodeBId Id of nodeB.
      * @return Pointer to the membrane that lies between these nodes.
      */
-    [[nodiscard]] std::shared_ptr<Membrane<T>> getMembraneBetweenNodes(size_t nodeAId, size_t nodeBId);
+    [[nodiscard]] std::shared_ptr<Membrane<T>> getMembraneBetweenNodes(size_t nodeAId, size_t nodeBId) const;
 
     /**
      * @brief Get the membrane that is connected to both specified nodes.
@@ -702,7 +702,7 @@ public:
      * @param nodeB Pointer to nodeB.
      * @return Pointer to the membrane that lies between these nodes.
      */
-    [[nodiscard]] std::shared_ptr<Membrane<T>> getMembraneBetweenNodes(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB) 
+    [[nodiscard]] std::shared_ptr<Membrane<T>> getMembraneBetweenNodes(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB) const
     {
         return getMembraneBetweenNodes(nodeA->getId(), nodeB->getId());
     }
@@ -718,14 +718,14 @@ public:
      * @param nodeId Id of the node.
      * @return Vector containing pointers to all membranes that are connected to this node.
      */
-    [[nodiscard]] std::vector<std::shared_ptr<Membrane<T>>> getMembranesAtNode(size_t nodeId);
+    [[nodiscard]] std::vector<std::shared_ptr<Membrane<T>>> getMembranesAtNode(size_t nodeId) const;
 
     /**
      * @brief Get vector of all membranes that are connected to the specified node.
      * @param node Pointer to the node.
      * @return Vector containing pointers to all membranes that are connected to this node.
      */
-    [[nodiscard]] inline std::vector<std::shared_ptr<Membrane<T>>> getMembranesAtNode(std::shared_ptr<Node<T>> node) 
+    [[nodiscard]] inline std::vector<std::shared_ptr<Membrane<T>>> getMembranesAtNode(std::shared_ptr<Node<T>> node) const
     { 
         return getMembranesAtNode(node->getId()); 
     }
@@ -771,7 +771,7 @@ public:
      * @param nodeBId Id of nodeB.
      * @return Pointer to the tank that lies between the two nodes.
      */
-    [[nodiscard]] std::shared_ptr<Tank<T>> getTankBetweenNodes(size_t nodeAId, size_t nodeBId);
+    [[nodiscard]] std::shared_ptr<Tank<T>> getTankBetweenNodes(size_t nodeAId, size_t nodeBId) const;
 
     /**
      * @brief Get the tank that lies between two nodes.
@@ -779,7 +779,7 @@ public:
      * @param nodeB Pointer to nodeB.
      * @return Pointer to the tank that lies between the two nodes.
      */
-    [[nodiscard]] inline std::shared_ptr<Tank<T>> getTankBetweenNodes(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB) 
+    [[nodiscard]] inline std::shared_ptr<Tank<T>> getTankBetweenNodes(const std::shared_ptr<Node<T>>& nodeA, const std::shared_ptr<Node<T>>& nodeB) const
     {
         return getTankBetweenNodes(nodeA->getId(), nodeB->getId());
     }

--- a/src/architecture/Network.h
+++ b/src/architecture/Network.h
@@ -15,6 +15,13 @@
 
 using json = nlohmann::json;
 
+namespace test::definitions {
+// Forward declared dependencies
+template<typename T>
+class GlobalTest;
+
+}
+
 namespace porting { 
 
 // Forward declared dependencies
@@ -22,6 +29,22 @@ template<typename T>
 void readNodes (json jsonString, arch::Network<T>& network);
 template<typename T>
 void readChannels (json jsonString, arch::Network<T>& network);
+
+}
+
+namespace nodal {
+
+// Forward declared dependencies
+template<typename T>
+class NodalAnalysis;
+
+}
+
+namespace sim {
+
+// Forward declared dependencies
+template<typename T>
+class Simulation;
 
 }
 
@@ -169,9 +192,45 @@ private:
     [[nodiscard]] size_t edgeCount() const;
 
     /**
-     * TODO: Today
+     * @brief Removes all edges from the network, that are connected to a specific node, but not channels and. hence, not in the reach of the node.
+     * @param[in] nodeId Id of the node for which the edges should be removed.
      */
     void removeEdgesFromNodeReach(size_t nodeId);
+
+    /**
+     * @brief Removes all flow rate pumps from the network, that are connected to a specific node.
+     * @param[in] nodeId Id of the node for which the flow rate pumps should be removed.
+     */ 
+    void removeFlowRatePumpsFromNodeReach(size_t nodeId);
+
+    /**
+     * @brief Removes all pressure pumps from the network, that are connected to a specific node.
+     * @param[in] nodeId Id of the node for which the pressure pumps should be removed.
+     */
+    void removePressurePumpsFromNodeReach(size_t nodeId);
+
+    /**
+     * @brief Removes all membranes from the network, that are connected to a specific node.
+     * @param[in] nodeId Id of the node for which the membranes should be removed.
+     */
+    void removeMembranesFromNodeReach(size_t nodeId);
+
+    /**
+     * @brief Removes all tanks from the network, that are connected to a specific node.
+     * @param[in] nodeId Id of the node for which the tanks should be removed.
+     */
+    void removeTanksFromNodeReach(size_t nodeId);
+
+    /**
+     * @brief Sorts the nodes and channels into detached abstract domain groups
+    */
+    void sortGroups();
+
+    /**
+     * @brief Get the groups in the network.
+     * @returns Groups
+    */
+    [[nodiscard]] inline const std::unordered_map<size_t, std::unique_ptr<Group<T>>>& getGroups() const { return groups; }
 
 public:
 
@@ -795,22 +854,6 @@ public:
     */
     [[nodiscard]] bool isTank(size_t edgeId) const { return tanks.find(edgeId) != tanks.end(); }
 
-
-    //=====================================================================================
-    //======================================== TODO =======================================
-    //=====================================================================================
-
-    /** TODO: Today
-     * @brief Get the groups in the network.
-     * @returns Groups
-    */
-    [[nodiscard]] inline const std::unordered_map<size_t, std::unique_ptr<Group<T>>>& getGroups() const { return groups; }
-
-    /** TODO: Today
-     * @brief Sorts the nodes and channels into detached abstract domain groups
-    */
-    void sortGroups();
-
     // Disable copy constructors
     Network<T>(const Network<T>& src) = delete;
     Network<T>(const Network<T>&& src) = delete;
@@ -823,6 +866,9 @@ public:
     ~Network<T>() = default;
 
     // friend definitions
+    friend class nodal::NodalAnalysis<T>;
+    friend class sim::Simulation<T>;
+    friend class test::definitions::GlobalTest<T>;
     friend void porting::readNodes<T>(json, arch::Network<T>&);
     friend void porting::readChannels<T>(json, arch::Network<T>&);
 };

--- a/src/architecture/Network.hh
+++ b/src/architecture/Network.hh
@@ -70,6 +70,66 @@ size_t Network<T>::edgeCount() const {
 }
 
 template<typename T>
+void Network<T>::removeEdgesFromNodeReach(size_t nodeId) {
+    removeFlowRatePumpsFromNodeReach(nodeId);
+    removePressurePumpsFromNodeReach(nodeId);
+    removeMembranesFromNodeReach(nodeId);
+    removeTanksFromNodeReach(nodeId);
+}
+
+template<typename T>
+void Network<T>::removeFlowRatePumpsFromNodeReach(size_t nodeId) {
+    // remove all flow rate pumps connected to this node
+    for (auto it = flowRatePumps.begin(); it != flowRatePumps.end(); ) {
+        auto pump = it->second;
+        if (pump->getNodeAId() == nodeId || pump->getNodeBId() == nodeId) {
+            it = flowRatePumps.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+template<typename T>
+void Network<T>::removePressurePumpsFromNodeReach(size_t nodeId) {
+    // remove all pressure pumps connected to this node
+    for (auto it = pressurePumps.begin(); it != pressurePumps.end(); ) {
+        auto pump = it->second;
+        if (pump->getNodeAId() == nodeId || pump->getNodeBId() == nodeId) {
+            it = pressurePumps.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+template<typename T>
+void Network<T>::removeMembranesFromNodeReach(size_t nodeId) {
+    // remove all membranes connected to this node
+    for (auto it = membranes.begin(); it != membranes.end(); ) {
+        auto membrane = it->second;
+        if (membrane->getNodeAId() == nodeId || membrane->getNodeBId() == nodeId) {
+            it = membranes.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+template<typename T>
+void Network<T>::removeTanksFromNodeReach(size_t nodeId) {
+    // remove all tanks connected to this node
+    for (auto it = tanks.begin(); it != tanks.end(); ) {
+        auto tank = it->second;
+        if (tank->getNodeAId() == nodeId || tank->getNodeBId() == nodeId) {
+            it = tanks.erase(it);
+        } else {    
+            ++it;
+        }
+    }
+}
+
+template<typename T>
 std::shared_ptr<Node<T>> Network<T>::addNode(T x_, T y_, bool ground_) {
     int nodeId = nodes.size();
 
@@ -448,6 +508,10 @@ std::shared_ptr<Tank<T>> Network<T>::getTankBetweenNodes(size_t nodeAId, size_t 
 
 template<typename T>
 void Network<T>::sortGroups() {
+    // clear existing groups
+    this->groups.clear();
+
+    // create a vector of all node ids and edges
     std::vector<size_t> nodeVector;
     std::vector<Edge<T>*> edges;
     int groupId = 0;
@@ -457,14 +521,14 @@ void Network<T>::sortGroups() {
     for (auto& [key, channel] : channels) {
         edges.emplace_back(channel.get());
     }
-    /*
     for (auto& [key, pump] : pressurePumps) {
         edges.emplace_back(pump.get());
     }
     for (auto& [key, pump] : flowRatePumps) {
         edges.emplace_back(pump.get());
     }
-    */
+
+    // while there are still nodes left, create groups of connected nodes
     while(!nodeVector.empty()){
         std::queue<size_t> connectedNodes;
         std::unordered_set<size_t> nodeIds;

--- a/src/architecture/Network.hh
+++ b/src/architecture/Network.hh
@@ -133,7 +133,7 @@ void Network<T>::setGround(size_t nodeId_) {
 }
 
 template<typename T>
-T Network<T>::calculateNodeDistance(size_t nodeAId, size_t nodeBId) {
+T Network<T>::calculateNodeDistance(size_t nodeAId, size_t nodeBId) const {
     auto& nodeA = this->getNodes().at(nodeAId);
     auto& nodeB = this->getNodes().at(nodeBId);
     T dx = nodeA->getPosition().at(0) - nodeB->getPosition().at(0);
@@ -152,9 +152,7 @@ void Network<T>::removeNode(const std::shared_ptr<Node<T>>& node) {
         }
 
         // remove node from connected module
-        for (auto& module : modularReach.at(nodeId)) {
-            module.second->removeNode(nodeId);
-        }
+        modularReach.at(nodeId)->removeNode(nodeId);
 
         // remove the node from the reach map
         reach.erase(nodeId);
@@ -393,7 +391,7 @@ std::shared_ptr<Membrane<T>> Network<T>::addMembraneToChannel(size_t channelId, 
 }
 
 template<typename T>
-std::shared_ptr<Membrane<T>> Network<T>::getMembrane(size_t membraneId) {
+std::shared_ptr<Membrane<T>> Network<T>::getMembrane(size_t membraneId) const {
     try {
         return membranes.at(membraneId);
     } catch (const std::out_of_range& e) {
@@ -402,7 +400,7 @@ std::shared_ptr<Membrane<T>> Network<T>::getMembrane(size_t membraneId) {
 }
 
 template<typename T>
-std::shared_ptr<Membrane<T>> Network<T>::getMembraneBetweenNodes(size_t nodeAId, size_t nodeBId) {
+std::shared_ptr<Membrane<T>> Network<T>::getMembraneBetweenNodes(size_t nodeAId, size_t nodeBId) const {
     for (auto& [key, membrane] : membranes) {
         if (((membrane->getNodeAId() == nodeAId) && (membrane->getNodeBId() == nodeBId)) || ((membrane->getNodeAId() == nodeBId) && (membrane->getNodeBId() == nodeAId))) {
             return membrane;
@@ -412,7 +410,7 @@ std::shared_ptr<Membrane<T>> Network<T>::getMembraneBetweenNodes(size_t nodeAId,
 }
 
 template<typename T>
-std::vector<std::shared_ptr<Membrane<T>>> Network<T>::getMembranesAtNode(size_t nodeId) {
+std::vector<std::shared_ptr<Membrane<T>>> Network<T>::getMembranesAtNode(size_t nodeId) const {
     std::vector<std::shared_ptr<Membrane<T>>> membrane_vector;
     for (auto& [key, membrane] : membranes) {
         if ((membrane->getNodeAId() == nodeId) || (membrane->getNodeBId() == nodeId)) {
@@ -439,9 +437,9 @@ std::shared_ptr<Tank<T>> Network<T>::addTankToMembrane(size_t membraneId, T heig
 }
 
 template<typename T>
-std::shared_ptr<Tank<T>> Network<T>::getTankBetweenNodes(size_t nodeAId, size_t nodeBId) {
+std::shared_ptr<Tank<T>> Network<T>::getTankBetweenNodes(size_t nodeAId, size_t nodeBId) const {
     for (auto& [key, tank] : tanks) {
-        if (((tank->getNodeAId()->getId() == nodeAId) && (tank->getNodeBId()->getId() == nodeBId)) || ((tank->getNodeAId()->getId() == nodeBId) && (tank->getNodeBId()->getId() == nodeAId))) {
+        if (((tank->getNodeAId() == nodeAId) && (tank->getNodeBId() == nodeBId)) || ((tank->getNodeAId() == nodeBId) && (tank->getNodeBId()== nodeAId))) {
             return tank;
         }
     }

--- a/src/architecture/Network.hh
+++ b/src/architecture/Network.hh
@@ -361,7 +361,7 @@ std::shared_ptr<CfdModule<T>> Network<T>::addCfdModule(std::vector<T> position,
 }
 
 template<typename T>
-void Network<T>::removeModule(const std::shared_ptr<CfdModule<T>>& module_) {
+void Network<T>::removeModule(const std::shared_ptr<Module<T>>& module_) {
     int moduleId = module_->getId();
     if (modules.find(moduleId) != modules.end()) {
         // remove module from reach of all nodes

--- a/src/architecture/definitions/ChannelPosition.h
+++ b/src/architecture/definitions/ChannelPosition.h
@@ -8,7 +8,7 @@ namespace arch {
 
 // Forward declared dependencies
 template<typename T>
-class RectangularChannel;
+class Channel;
 
 /**
  * @brief Class to specify the boundary position of one end of a droplet.

--- a/src/architecture/entities/Channel.h
+++ b/src/architecture/entities/Channel.h
@@ -112,8 +112,8 @@ private:
     T channelResistance = 0;                    ///< Resistance of a channel in Pas/L.
     T dropletResistance = 0;                    ///< Additional resistance of present droplets in the channel in Pas/L.
     
-    std::vector<std::unique_ptr<Line_segment<T,2>>> line_segments;      ///< Straight line segments in the channel.
-    std::vector<std::unique_ptr<Arc<T,2>>> arcs;                        ///< Arcs in the channel.
+    std::vector<Line_segment<T,2>> line_segments;      ///< Straight line segments in the channel.
+    std::vector<Arc<T,2>> arcs;                        ///< Arcs in the channel.
 
 protected:
     /**
@@ -125,7 +125,7 @@ protected:
      * @param[in] arcs The arcs of this channel.
     */
     Channel(size_t id, std::shared_ptr<Node<T>> nodeA, std::shared_ptr<Node<T>> nodeB, 
-            std::vector<Line_segment<T,2>*> line_segments, std::vector<Arc<T,2>*> arcs,
+            std::vector<Line_segment<T,2>> line_segments, std::vector<Arc<T,2>> arcs,
             ChannelShape shape);
 
     /**

--- a/src/architecture/entities/Channel.h
+++ b/src/architecture/entities/Channel.h
@@ -45,6 +45,9 @@ template<typename T>
 class Node;
 
 template<typename T>
+class Network;
+
+template<typename T>
 class CfdModule;
 
 /**

--- a/src/architecture/entities/Channel.h
+++ b/src/architecture/entities/Channel.h
@@ -175,7 +175,7 @@ public:
     inline void setChannelType(ChannelType channelType) { this->type = channelType; }
 
     /**
-     * @brief Returns the shape of channel.
+     * @brief Returns the shape of channel cross-section.
      * @returns What shape the channel has.
      */
     [[nodiscard]] inline ChannelShape getChannelShape() const { return shape; }
@@ -217,7 +217,7 @@ public:
     [[nodiscard]] inline T getFlowRate() const override { return getPressure() / getResistance(); }
 
     /**
-     * @brief Returns area of a channel.
+     * @brief Returns area of a channel cross-section.
      * @returns Area in m^2.
      */
     [[nodiscard]] inline T getArea() const { return area; }

--- a/src/architecture/entities/Channel.hh
+++ b/src/architecture/entities/Channel.hh
@@ -64,26 +64,14 @@ T Arc<T,DIM>::getLength() {
 template<typename T>
 Channel<T>::Channel(size_t id_, std::shared_ptr<Node<T>> nodeA_, std::shared_ptr<Node<T>> nodeB_, ChannelShape shape_) : 
 Edge<T>(id_, nodeA_->getId(), nodeB_->getId()), shape(shape_) { 
-    std::unique_ptr<Line_segment<T,2>> line = std::make_unique<Line_segment<T,2>> (nodeA_->getPosition(), nodeB_->getPosition());
-    this->length = line->getLength();
+    Line_segment<T,2> line = Line_segment<T,2> (nodeA_->getPosition(), nodeB_->getPosition());
     line_segments.push_back(std::move(line));
 }
 
 template<typename T>
 Channel<T>::Channel(size_t id_, std::shared_ptr<Node<T>> nodeA_, std::shared_ptr<Node<T>> nodeB_,
-                    std::vector<Line_segment<T,2>*> line_segments_, std::vector<Arc<T,2>*> arcs_, ChannelShape shape_) :
-Edge<T>(id_, nodeA_->getId(), nodeB_->getId()), shape(shape_) {
-    for (auto& line : line_segments_) {
-        this->length += line->getLength();
-        std::unique_ptr<Line_segment<T,2>> uLine(line);
-        line_segments.push_back(std::move(uLine));
-    }
-    for (auto& arc : arcs_) {
-        this->length += arc->getLength();
-        std::unique_ptr<Arc<T,2>> uArc(arc);
-        arcs.push_back(std::move(uArc));
-    }
-}
+                    std::vector<Line_segment<T,2>> line_segments_, std::vector<Arc<T,2>> arcs_, ChannelShape shape_) :
+Edge<T>(id_, nodeA_->getId(), nodeB_->getId()), line_segments(std::move(line_segments_)), arcs(std::move(arcs_)), shape(shape_) { }
 
 //=====================================================================================
 //================================  RectangularChannel ================================

--- a/src/architecture/entities/Edge.h
+++ b/src/architecture/entities/Edge.h
@@ -42,14 +42,14 @@ public:
   [[nodiscard]] inline size_t getId() const { return id; }
 
   /**
-   * @brief Get pointer to node 0 (node at one end of the edge).
-   * @return Pointer to node 0 (node at one end of the edge).
+   * @brief Get the id of node A(node at one end of the edge).
+   * @return Id of node A (node at one end of the edge).
    */
   [[nodiscard]] inline size_t getNodeAId() const { return nodeA; }
 
   /**
-   * @brief Get pointer to node 1 (node at other end of the edge).
-   * @return Pointer to node 1 (node at other end of the edge).
+   * @brief Get the id of node B (node at other end of the edge).
+   * @return Id of node B (node at other end of the edge).
    */
   [[nodiscard]] inline size_t getNodeBId() const { return nodeB; }
 

--- a/src/architecture/entities/FlowRatePump.h
+++ b/src/architecture/entities/FlowRatePump.h
@@ -19,7 +19,7 @@ template<typename T>
 class Edge;
 
 template<typename T>
-class Node;
+class Network;
 
 /**
  * @brief Class to specify a flow rate pump, which is a component of a chip.

--- a/src/architecture/entities/Membrane.h
+++ b/src/architecture/entities/Membrane.h
@@ -143,6 +143,13 @@ class Membrane : public Edge<T> {
     [[nodiscard]] std::shared_ptr<Channel<T>> getChannel() const;
 
     /**
+     * @brief Get pointer to the rectangular channel the membrane is connected to.
+     * @return Pointer to the rectangular channel the membrane is connected to.
+     * @throws logic_error if the stored channel is not of rectangular shape.
+     */
+    [[nodiscard]] std::shared_ptr<RectangularChannel<T>> getRectangularChannel() const;
+
+    /**
     * @brief Get pointer to the tank the membrane is connected to.
     * @return Pointer to the tank the membrane is connected to.
     */

--- a/src/architecture/entities/Membrane.h
+++ b/src/architecture/entities/Membrane.h
@@ -145,7 +145,7 @@ class Membrane : public Edge<T> {
     /**
      * @brief Get pointer to the rectangular channel the membrane is connected to.
      * @return Pointer to the rectangular channel the membrane is connected to.
-     * @throws logic_error if the stored channel is not of rectangular shape.
+     * @throws bad_cast if the stored channel is not of rectangular shape.
      */
     [[nodiscard]] std::shared_ptr<RectangularChannel<T>> getRectangularChannel() const;
 

--- a/src/architecture/entities/Membrane.hh
+++ b/src/architecture/entities/Membrane.hh
@@ -73,6 +73,15 @@ std::shared_ptr<Channel<T>> Membrane<T>::getChannel() const {
 }
 
 template<typename T>
+std::shared_ptr<RectangularChannel<T>> Membrane<T>::getRectangularChannel() const {
+    if(channel->isRectangular()) {
+        return std::dynamic_pointer_cast<RectangularChannel<T>>(channel);
+    } else {
+        throw std::bad_cast();
+    }
+}
+
+template<typename T>
 std::shared_ptr<Tank<T>> Membrane<T>::getTank() const {
     return tank;
 }

--- a/src/architecture/entities/Module.h
+++ b/src/architecture/entities/Module.h
@@ -17,6 +17,12 @@ class CfdSimulator;
 template<typename T>
 class ResistanceModel;
 
+template<typename T>
+class lbmSimulator;
+
+template<typename T>
+class essLbmSimulator;
+
 }
 
 namespace arch {
@@ -96,6 +102,16 @@ protected:
      */
     virtual void removeNode(size_t nodeId) { boundaryNodes.erase(nodeId); }
 
+    /**
+     * @brief Sets the type of the module to LBM.
+     */
+    inline void setModuleTypeLbm() { moduleType = ModuleType::LBM; }
+
+    /**
+     * @brief Returns the type of the module to ESS LBM.
+     */
+    inline void setModuleTypeEssLbm() { moduleType = ModuleType::ESS_LBM; }
+
 public:
 
     /**
@@ -122,23 +138,15 @@ public:
     */
     [[nodiscard]] inline const std::unordered_map<size_t, std::shared_ptr<Node<T>>>& getNodes() const { return boundaryNodes; }
 
-    /** TODO: Shouldn't this be hidden, and set by inherited object? (today)
-     * @brief Returns the type of the module.
-     * @returns What type the channel has.
-     */
-    inline void setModuleTypeLbm() { moduleType = ModuleType::LBM; }
-
-    /**
-     * @brief Returns the type of the module.
-     * @returns What type the channel has.
-     */
-    inline void setModuleTypeEssLbm() { moduleType = ModuleType::ESS_LBM; }
-
     /**
      * @brief Returns the type of the module.
      * @returns What type the channel has.
      */
     [[nodiscard]] inline ModuleType getModuleType() const { return moduleType; }
+
+    // Friend definitions
+    friend class sim::lbmSimulator<T>;
+    friend class sim::essLbmSimulator<T>;
 };
 
 /**

--- a/src/architecture/entities/Module.h
+++ b/src/architecture/entities/Module.h
@@ -90,6 +90,12 @@ protected:
     */
     inline void setNodes(std::unordered_map<size_t, std::shared_ptr<Node<T>>> boundaryNodes) { this->boundaryNodes = boundaryNodes; }
 
+    /**
+     * @brief Removes a node from the module.
+     * @param[in] nodeId Id of the node that should be removed.
+     */
+    virtual void removeNode(size_t nodeId) { boundaryNodes.erase(nodeId); }
+
 public:
 
     /**
@@ -164,6 +170,12 @@ private:
      * @param[in] resistanceModel The resistance model that is used in the simulator to obtain channel resistances.
      */
     void initialize(const sim::ResistanceModel<T>* resistanceModel);
+
+    /**
+     * @brief Removes a node and its opening from the CFD module.
+     * @param[in] nodeId Id of the node that should be removed.
+     */
+    void removeNode(size_t nodeId) override;
 
 public:
 

--- a/src/architecture/entities/Module.h
+++ b/src/architecture/entities/Module.h
@@ -12,7 +12,7 @@ namespace sim {
 
 // Forward declared dependencies
 template<typename T>
-class CfdSimulator;
+class CFDSimulator;
 
 template<typename T>
 class ResistanceModel;
@@ -30,6 +30,9 @@ namespace arch {
 // Forward declared dependencies
 template<typename T>
 class Node;
+
+template<typename T>
+class Network;
 
 template<typename T>
 struct Opening;

--- a/src/architecture/entities/Module.h
+++ b/src/architecture/entities/Module.h
@@ -116,7 +116,7 @@ public:
     */
     [[nodiscard]] inline const std::unordered_map<size_t, std::shared_ptr<Node<T>>>& getNodes() const { return boundaryNodes; }
 
-    /**
+    /** TODO: Shouldn't this be hidden, and set by inherited object? (today)
      * @brief Returns the type of the module.
      * @returns What type the channel has.
      */

--- a/src/architecture/entities/Module.hh
+++ b/src/architecture/entities/Module.hh
@@ -52,6 +52,12 @@ void CfdModule<T>::initialize(const sim::ResistanceModel<T>* resistanceModel_) {
 }
 
 template<typename T>
+void CfdModule<T>::removeNode(size_t nodeId) {
+    Module<T>::removeNode(nodeId);
+    moduleOpenings.erase(nodeId);
+}
+
+template<typename T>
 void CfdModule<T>::assertInitialized() {
     /**
      * TODO: Miscellaneous

--- a/src/architecture/entities/Node.h
+++ b/src/architecture/entities/Node.h
@@ -52,7 +52,7 @@ public:
     [[nodiscard]] inline size_t getId() const { return id; }
 
     /**
-     * @brief Get position of the node.
+     * @brief Set position of the node.
      * @param[in] pos Vector of the absolute position of the node.
     */
     inline void setPosition(std::vector<T> pos) { this->pos =  std::move(pos); }

--- a/src/architecture/entities/Node.h
+++ b/src/architecture/entities/Node.h
@@ -16,6 +16,9 @@ class NodalAnalysis;
 
 namespace arch {
 
+template<typename T>
+class Network;
+
 /**
  * @brief Class to specify a node, which defines connections between components of a Network.
 */

--- a/src/architecture/entities/PressurePump.h
+++ b/src/architecture/entities/PressurePump.h
@@ -19,7 +19,7 @@ template<typename T>
 class Edge;
 
 template<typename T>
-class Node;
+class Network;
 
 /**
  * @brief Class to specify a pressure pump, which is a component of a chip.

--- a/src/baseSimulator.hh
+++ b/src/baseSimulator.hh
@@ -47,9 +47,10 @@
 
 #include "architecture/Network.hh"
 
-#include "olbProcessors/navierStokesAdvectionDiffusionCouplingPostProcessor2D.hh"
-#include "olbProcessors/saturatedFluxPostProcessor2D.hh"
-#include "olbProcessors/setFunctionalRegularizedHeatFlux.hh"
+//** TODO: HybridOocSimulation */
+// #include "olbProcessors/navierStokesAdvectionDiffusionCouplingPostProcessor2D.hh"
+// #include "olbProcessors/saturatedFluxPostProcessor2D.hh"
+// #include "olbProcessors/setFunctionalRegularizedHeatFlux.hh"
 
 #include "porting/jsonPorter.hh"
 #include "porting/jsonReaders.hh"

--- a/src/porting/jsonPorter.hh
+++ b/src/porting/jsonPorter.hh
@@ -100,8 +100,6 @@ std::unique_ptr<sim::Simulation<T>> simulationFromJSON(json jsonString, std::sha
 
         readContinuousPhase<T>(jsonString, *simPtr, activeFixture);
         readResistanceModel<T>(jsonString, *simPtr);
-        network_->sortGroups();
-        network_->isNetworkValid();
     }
 
     // Read a Hybrid simulation definition
@@ -114,7 +112,6 @@ std::unique_ptr<sim::Simulation<T>> simulationFromJSON(json jsonString, std::sha
             readResistanceModel<T>(jsonString, *simPtr);
             readSimulators<T>(jsonString, *(dynamic_cast<sim::HybridContinuous<T>*>(simPtr.get())), network_.get());
             readUpdateScheme(jsonString, *(dynamic_cast<sim::HybridContinuous<T>*>(simPtr.get())));
-            network_->sortGroups();
         } else if (platform == sim::Platform::Mixing) {
             throw std::invalid_argument("Mixing simulations are currently only supported for Abstract simulations.");
             /** TODO: HybridMixingSimulation

--- a/src/porting/jsonWriters.hh
+++ b/src/porting/jsonWriters.hh
@@ -118,7 +118,7 @@ auto writeMixtures (sim::AbstractMixing<T>* simulation) {
     for (size_t i=0; i<simMixtures.size(); ++i) {
         auto Mixture = ordered_json::object();
         auto& simMixture = simMixtures.at(i);
-        for(auto& [key, specie] : simMixture->readSpecies()) {
+        for(auto& [key, specie] : simMixture->getSpecies()) {
             Mixture["species"].push_back(specie->getId());
             Mixture["concentrations"].push_back(simMixture->getConcentrationOfSpecie(specie));
         }

--- a/src/simulation/entities/Droplet.h
+++ b/src/simulation/entities/Droplet.h
@@ -235,6 +235,10 @@ class Droplet {
     T volume = 1e-11;                                               ///< Volume of the droplet in m^3.
     Fluid<T>* fluid = nullptr;                                      ///< Pointer to fluid of which the droplet consists of.
 
+    /** TODO: Miscellaneous
+     * Add a simHash for integrity checks between fluids, droplets and mixtures.
+     */
+
   protected:
     std::vector<std::unique_ptr<DropletBoundary<T>>> boundaries;    ///< Boundaries of the droplet.
     std::vector<arch::Channel<T>*> channels;                        ///< Contains the channels, that are completely occupied by the droplet (can happen in short channels or with large droplets).
@@ -284,14 +288,12 @@ class Droplet {
      */
     [[nodiscard]] inline const Fluid<T>* readFluid() const { return fluid; }
 
-    /** TODO: Miscellaneous */
     /**
      * @brief Set the fluid of this droplet.
-     * TODO add SimHash to confirm this fluid belongs to same simulator
      * @param[in] fluid A pointer to the fluid that composes the droplet.
      * @throws a logic_error is the fluid pointer is a nullptr.
      */
-    void setFluid(Fluid<T>* fluid);
+    void setFluid(const std::shared_ptr<Fluid<T>>& fluid);
 
     /**
      * @brief A vector to read-only references of the droplet boundaries.

--- a/src/simulation/entities/Droplet.hh
+++ b/src/simulation/entities/Droplet.hh
@@ -12,9 +12,9 @@ Droplet<T>::Droplet(size_t id, T volume, Fluid<T>* fluid) :
     id(id), volume(volume), fluid(fluid) { }
 
 template<typename T>
-void Droplet<T>::setFluid(Fluid<T>* fluid) {
+void Droplet<T>::setFluid(const std::shared_ptr<Fluid<T>>& fluid) {
     if(fluid) {
-        this->fluid = fluid;
+        this->fluid = fluid.get();
     } else{
         throw std::logic_error("Tried to set invalid fluid for droplet: nullPtr.");
     }

--- a/src/simulation/entities/Fluid.h
+++ b/src/simulation/entities/Fluid.h
@@ -33,6 +33,10 @@ class Fluid {
     T viscosity = 1.0e-3;                                   ///< Dynamic viscosity of the continuous phase in [Pa s].
     T molecularSize { std::numeric_limits<T>::epsilon() };  ///< Molecular size in [m^3].
 
+    /** TODO: Miscellaneous
+     * Add a simHash for integrity checks between fluids, droplets and mixtures.
+     */
+
     /**
      * @brief A static member function that resets the fluid object counter to zero.
      * Used as a helper function to reset the static variable between tests.

--- a/src/simulation/entities/Mixture.h
+++ b/src/simulation/entities/Mixture.h
@@ -320,7 +320,7 @@ public:
 
     /**
      * @brief Get the viscosity of the mixture.
-     * @return Viscosity of the mixture in Pas.
+     * @return Viscosity of the mixture in Pa s.
      */
     [[nodiscard]] inline T getViscosity() const {return viscosity; }
 

--- a/src/simulation/entities/Mixture.h
+++ b/src/simulation/entities/Mixture.h
@@ -185,7 +185,7 @@ public:
     /**
      * @brief Overload == operator to check if mixtures are equal or not
      */
-    bool operator== (const Mixture<T>& t);
+    bool operator== (const Mixture<T>& t) const;
 
     /**
      * @brief Get the id of this mixture

--- a/src/simulation/entities/Mixture.h
+++ b/src/simulation/entities/Mixture.h
@@ -77,12 +77,13 @@ private:
     size_t simHash = 0;                                             ///< Hash of the simulation that created this mixture object.
     const size_t id;                                                ///< Unique identifier of the mixture.   
     std::string name = "";                                          ///< Name of the mixture.   
-    std::unordered_map<size_t, Specie<T>*> species;                 ///< Map of specie id and pointer to the specie in this mixture.
-    std::unordered_map<size_t, T> specieConcentrations;             ///< Map of specie id and concentration.
+    std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species; ///< Map of specie id and pointer to the specie in this mixture.
+    std::unordered_map<size_t, T> specieConcentrations;             ///< Map of specie id and concentration [g/m^3].
     T viscosity;                                                    ///< Viscosity of this mixture, defaults to bulk (continuous phase) viscosity.
     T density;                                                      ///< Density of this mixture, defaults to bulk (continuous phase) density.
     T largestMolecularSize;                                         ///< Largest molecular size in the mixture in [m^3].
-    bool isMutable = false;                                         ///< Is this Mixture object mutable through the plublic API?
+    bool isMutable = false;                                         ///< Is this Mixture object mutable through the plublic API? E.g., a mixture created
+                                                                    ///< by the user through AbstractMixing::addMixture() is mutable, a mixture created by a MixingModel is not.
 
     /**
      * @brief A static member function that resets the mixture object counter to zero.
@@ -106,7 +107,7 @@ private:
      * @param density Density of the mixture in kg/m^3.
      * @param largestMolecularSize Largest molecular size in that mixture in m^3.
      */
-    Mixture(size_t id, std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations, Fluid<T>* carrierFluid);
+    Mixture(size_t id, std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations, Fluid<T>* carrierFluid);
 
     /**
      * @brief Set a Mixture object to be mutable.
@@ -131,7 +132,7 @@ protected:
      * @param density Density of the mixture in kg/m^3.
      * @param largestMolecularSize Largest molecular size in that mixture in m^3.
      */
-    Mixture(size_t simHash, size_t id, std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations, T viscosity, T density, T largestMolecularSize=0.0);
+    Mixture(size_t simHash, size_t id, std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations, T viscosity, T density, T largestMolecularSize=0.0);
 
     /**
      * @brief Construct a new mixture out of a list of fluids and their concentration values.
@@ -140,7 +141,7 @@ protected:
      * @param fluidConcentrations Map of fluid id and fluid concentration pairs.
      * @param fluid Carrier fluid of the mixture.
      */
-    Mixture(size_t simHash, size_t id, std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations, Fluid<T>* carrierFluid);
+    Mixture(size_t simHash, size_t id, std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations, Fluid<T>* carrierFluid);
 
     /**
      * @brief Checks whether this object is mutable or not.
@@ -163,23 +164,19 @@ protected:
     [[nodiscard]] T getConcentrationOfSpecie(size_t specieId) const;
 
     /**
-     * @brief Get a map of all flud id ids and their volume concentrations of the mixture.
-     * @return Map of fluid id and volume concentration pairs.
-     */
-    [[nodiscard]] inline const std::unordered_map<size_t, T>& getSpecieConcentrations() const { return specieConcentrations; }
-
-    /**     
-     * @brief Get the species that are contained in this mixture.
-     * @return Map of specie id and pointer to the specie in this mixture.
-    */
-    [[nodiscard]] inline const std::unordered_map<size_t, Specie<T>*>& getSpecies() const { return species; }
-
-    /**
      * @brief Update a specie concentration for a given specie for a given difference.
      * @param[in] specieId Identifier of the specie for which the concentration should be changed.
      * @param[in] concentrationChange The concentration difference. The new value is old + difference.
      */
     void changeSpecieConcentration(int specieId, T concentrationChange);
+
+    /**
+     * @brief Removes a specie from a mixture, if it is mutable.
+     * @param[in] speciePtr pointer to the specie that should be removed from the mixture.
+     * @return True if the specie was removed successfully, false if it was not listed.
+     * @throws invalid_argument if the specie is not listed in the Mixture.
+     */
+    [[maybe_unused]] bool forceRemoveSpecie(std::shared_ptr<Specie<T>>& speciePtr);
 
 public:
     /**
@@ -214,18 +211,7 @@ public:
      * @note A specie can only be added to mutable Mixture objects.
      * @note A specie can only be added if they were created by the same Simulation object.
      */
-    [[maybe_unused]] bool addSpecie(Specie<T>* speciePtr, T concentration);
-
-    /**
-     * @brief Adds a specie to a mixture.
-     * @param[in] speciePtr A pointer to the Specie object that is to be added.
-     * @param[in] concentration The concentration value of the specie.
-     * @returns True if the specie was added successfully, false if it was already listed.
-     * @throws invalid_argument if the passed Specie is already listed in the Mixture object.
-     * @note A specie can only be added to mutable Mixture objects.
-     * @note A specie can only be added if they were created by the same Simulation object.
-     */
-    [[maybe_unused]] bool addSpecie(std::shared_ptr<Specie<T>>& speciePtr, T concentration);
+    [[maybe_unused]] bool addSpecie(std::shared_ptr<Specie<T>> speciePtr, T concentration);
 
     /** 
      * @brief Returns a read-only pointer to a set of <specie, concentration>.
@@ -233,27 +219,19 @@ public:
      * @returns std::tuple<speciePtr, concentration>
      * @throws invalid_argument if the specie is not listed in the mixture.
      */
-    std::tuple<const Specie<T>*, T> readSpecie(size_t specieId) const;
+    [[nodiscard]] const std::tuple<std::shared_ptr<Specie<T>>, T> getSpecie(size_t specieId) const;
 
     /**
      * @brief Returns a read-only map the listed species
      * @returns Copy of the species unordered_map<id, const specie<T>*>
      */
-    std::unordered_map<size_t, const Specie<T>*> readSpecies() const;
+    [[nodiscard]] inline const std::unordered_map<size_t, std::shared_ptr<Specie<T>>> getSpecies() const { return species; }
 
     /**
      * @brief Returns a read-only map of the listed specieConcentrations
      * @returns Reference of the concentrations unordered_map<id, conc>
      */
-    const std::unordered_map<size_t, T>& readSpecieConcentrations() const { return specieConcentrations; }
-
-    /**
-     * @brief Get the concentration of a specific specie in that mixture.
-     * @param[in] speciePtr Pointer to the specie.
-     * @return Volume concentration of that specie within the mixture.
-     * @throws invalid_argument if the specie is not listed in the mixture.
-     */
-    [[nodiscard]] T getConcentrationOfSpecie(const Specie<T>* speciePtr) const;
+    [[nodiscard]] inline const std::unordered_map<size_t, T>& getSpecieConcentrations() const { return specieConcentrations; }
 
     /**
      * @brief Get the concentration of a specific specie in that mixture.
@@ -279,15 +257,6 @@ public:
      * @returns True if the concentration was set successfully.
      * @throws invalid_argument if the specie is not listed in the mixture.
      */
-    [[maybe_unused]] bool setSpecieConcentration(const Specie<T>* speciePtr, T concentration);
-
-    /**
-     * @brief Set a new concentration value for a Specie listed in this mixture.
-     * @param[in] speciePtr Pointer to the Specie which is listed.
-     * @param[in] concentration New concentration value.
-     * @returns True if the concentration was set successfully.
-     * @throws invalid_argument if the specie is not listed in the mixture.
-     */
     [[maybe_unused]] bool setSpecieConcentration(const std::shared_ptr<Specie<T>>&, T concentration);
 
     /**
@@ -295,14 +264,6 @@ public:
      * @return Number of species in this mixture.
      */
     [[nodiscard]] inline size_t getSpecieCount() const { return species.size(); }
-
-    /**
-     * @brief Removes a specie from a mixture, if it is mutable.
-     * @param[in] speciePtr pointer to the specie that should be removed from the mixture.
-     * @return True if the specie was removed successfully, false if it was not listed.
-     * @throws invalid_argument if the specie is not listed in the Mixture.
-     */
-    [[maybe_unused]] bool removeSpecie(Specie<T>* speciePtr);
 
     /**
      * @brief Removes a specie from a mixture, if it is mutable.
@@ -324,10 +285,9 @@ public:
      */
     [[nodiscard]] inline T getViscosity() const {return viscosity; }
 
-    /** TODO: Miscellaneous */
     /** This value should be updated once a while
      * @brief Get the largest molecular size in this mixture.
-     * @return Largest molecular size in the mixture in \\TODO unit.
+     * @return Largest molecular size in the mixture in m^3.
      */
     [[nodiscard]] inline T getLargestMolecularSize() const {return largestMolecularSize;}
 
@@ -358,7 +318,7 @@ private:
      * @param largestMolecularSize Largest molecular size in the mixture in [m^3].
      * @param resolution Spectral resolution of the distribution function.
      */
-    DiffusiveMixture(size_t simHash, size_t id, std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations, 
+    DiffusiveMixture(size_t simHash, size_t id, std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations, 
         std::unordered_map<size_t, std::tuple<std::function<T(T)>, std::vector<T>,T>> specieDistributions,T viscosity, T density, T largestMolecularSize, int resolution=10);
     
     /**
@@ -372,7 +332,7 @@ private:
      * @param largestMolecularSize Largest molecular size in the mixture in [m^3].
      * @param resolution Spectral resolution of the distribution function.
      */
-    DiffusiveMixture(size_t simHash, size_t id, std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations, 
+    DiffusiveMixture(size_t simHash, size_t id, std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations, 
         std::unordered_map<size_t, std::tuple<std::function<T(T)>, std::vector<T>,T>> specieDistributions, T viscosity, T density, int resolution=10);
 
     /**
@@ -386,7 +346,7 @@ private:
      * @param largestMolecularSize Largest molecular size in the mixture in [m^3].
      * @param resolution Spectral resolution of the distribution function.
      */
-    DiffusiveMixture(size_t simHash, size_t id, std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations, 
+    DiffusiveMixture(size_t simHash, size_t id, std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations, 
         std::unordered_map<size_t, std::tuple<std::function<T(T)>, std::vector<T>,T>> specieDistributions, Fluid<T>* carrierFluid, int resolution=10);
 
     /**
@@ -409,13 +369,6 @@ private:
     inline void setNonConstant() { this->isConstant = false; }
 
 public:
-
-    /**
-     * @brief Get the distribution function of a specific specie in this mixture.
-     * @param[in] speciePtr Pointer to the specie.
-     * @return Distribution function of the specie.`
-     */
-    [[nodiscard]] std::function<T(T)> getDistributionOfSpecie(const Specie<T>* speciePtr) const;
 
     /**
      * @brief Get the distribution function of a specific specie in this mixture.

--- a/src/simulation/entities/Mixture.h
+++ b/src/simulation/entities/Mixture.h
@@ -152,7 +152,7 @@ protected:
      * @brief Checks whether the provided specie is created by the same Simulation object.
      * @throws invalid_argument if Specie's hash does not match the Mixture hash.
      */
-    bool checkHashes(Specie<T>* speciePtr) const;
+    bool checkHashes(const Specie<T>* speciePtr) const;
 
     /**
      * @brief Get the concentration of a specific specie in that mixture.

--- a/src/simulation/entities/Mixture.hh
+++ b/src/simulation/entities/Mixture.hh
@@ -27,7 +27,7 @@ bool Mixture<T>::checkMutability() const {
 }
 
 template<typename T>
-bool Mixture<T>::checkHashes(Specie<T>* speciePtr) const {
+bool Mixture<T>::checkHashes(const Specie<T>* speciePtr) const {
     if (speciePtr->getHash() != simHash) {
         throw std::invalid_argument("Hash mismatch. Specie was removed from Simulation or created by other Simulation.");
     }
@@ -71,8 +71,8 @@ bool Mixture<T>::addSpecie(Specie<T>* speciePtr, T concentration) {
     checkHashes(speciePtr);
 
     // Checks passed, we can add the new specie
-    auto& result1 = species.try_emplace(key, speciePtr);
-    auto& result2 = specieConcentrations.try_emplace(key, concentration);
+    auto result1 = species.try_emplace(key, speciePtr);
+    auto result2 = specieConcentrations.try_emplace(key, concentration);
 
     return result1.second && result2.second; // Return true if both insertions were successful
 }
@@ -145,8 +145,8 @@ bool Mixture<T>::removeSpecie(Specie<T>* speciePtr) {
     if (species.find(key) == species.end()) {
         throw std::invalid_argument("Cannot set concentration for specie with id: " + std::to_string(speciePtr->getId()) + ". Specie not found.");
     }
-    auto& result1 = specieConcentrations.erase(key); 
-    auto& result2 = species.erase(key);
+    auto result1 = specieConcentrations.erase(key); 
+    auto result2 = species.erase(key);
 
     return (result1 > 0 && result2 > 0); // Return true if both removals were successful
 }

--- a/src/simulation/entities/Mixture.hh
+++ b/src/simulation/entities/Mixture.hh
@@ -50,7 +50,7 @@ void Mixture<T>::changeSpecieConcentration(int specieId, T concentrationChange) 
 }
 
 template<typename T>
-bool Mixture<T>::operator== (const Mixture<T>& t) {
+bool Mixture<T>::operator== (const Mixture<T>& t) const {
     if (species == t.species && 
         specieConcentrations == t.specieConcentrations && 
         viscosity == t.viscosity &&

--- a/src/simulation/entities/Specie.h
+++ b/src/simulation/entities/Specie.h
@@ -20,6 +20,9 @@ namespace sim {
 template<typename T>
 class AbstractMixing;
 
+template<typename T>
+class Mixture;
+
 /**
  * @brief Class to define a specie.
  */
@@ -61,6 +64,12 @@ class Specie {
      * @param[in] simHash Hash of the simulation that created this specie object.
      */
     void resetHash() noexcept { this->simHash = 0; }
+
+    /**
+     * @brief Returns the simulation hash of this specie.
+     * @returns The hash of the simulation that created the specie.
+     */
+    size_t getHash() const noexcept { return this->simHash; }
 
   public:
 
@@ -108,6 +117,7 @@ class Specie {
 
     // Friend class definitions
     friend class AbstractMixing<T>;
+    friend class Mixture<T>;
     friend class test::definitions::GlobalTest<T>;
 
 };

--- a/src/simulation/events/InjectionEvent.hh
+++ b/src/simulation/events/InjectionEvent.hh
@@ -10,7 +10,7 @@ template<typename T>
 void DropletInjectionEvent<T>::performEvent() {
     // injection position of the droplet (center of the droplet)
     auto channelPosition = injection.getInjectionPosition();
-    auto channel = channelPosition.getChannel();
+    auto channel = injection.getInjectionChannel().get();
     auto droplet = injection.getDroplet();
 
     // for the injection the two boundaries (basically a head and a tail) of the droplet must lie inside the channel (the volume of the droplet must be small enough)
@@ -20,8 +20,8 @@ void DropletInjectionEvent<T>::performEvent() {
     T dropletLength = droplet->getVolume() / channel->getVolume();
 
     // compute position of the two boundaries
-    T position0 = (channelPosition.getPosition() - dropletLength / 2);  // is always the position which lies closer to 0
-    T position1 = (channelPosition.getPosition() + dropletLength / 2);  // is always the position which lies closer to 1
+    T position0 = (channelPosition - dropletLength / 2);  // is always the position which lies closer to 0
+    T position1 = (channelPosition + dropletLength / 2);  // is always the position which lies closer to 1
 
     // create corresponding boundaries
     // since boundary0 always lies closer to 0, the volume of this boundary points to node1

--- a/src/simulation/models/MembraneModels.h
+++ b/src/simulation/models/MembraneModels.h
@@ -51,6 +51,9 @@ public:
 
 };
 
+/** TODO: HybridOocSimulation
+ * Check if a Permeability membrane model is relevant
+ */
 // /**
 //  * @brief Class that describes the poreResistance membrane model. This membrane model derives the permeability from pore geometry.
 // */
@@ -67,6 +70,9 @@ public:
 //     friend class AbstractMembrane<T>;
 // };
 
+/** TODO: HybridOocSimulation
+ * Check if a PoreResistance membrane model is relevant
+ */
 // /**
 //  * @brief Class that describes the poreResistance membrane model. This membrane model derives the permeability from pore geometry.
 // */
@@ -84,27 +90,24 @@ public:
 
 // };
 
-/** TODO: Miscellaneous
- * Fix Specie/Mixture inconsistency
- */
 /**
  * @brief Class that defines the functionality of the 1D membrane resistance model.
  * Membrane Resistance Model 0
  * Based on Source: M. Ishahak, J. Hill, Q. Amin, L. Wubker, A. Hernandez, A. Mitrofanova, A. Sloan, A. Fornoni and A. Agarwal. "Modular Microphysiological System for Modeling of Biologic Barrier Function". In: Front. Bioeng. Biotechnol. 8:581163. (2020). doi: 10.3389/fbioe.2020.581163
  */
-// template<typename T>
-// class MembraneModel0 final : public MembraneModel<T> {
+template<typename T>
+class MembraneModel0 final : public MembraneModel<T> {
 
-//   private:
+  private:
 
-//     MembraneModel0();
+    MembraneModel0();
 
-//     [[nodiscard]] T getPoreResistance(const std::shared_ptr<arch::Membrane<T>>&  membrane, Mixture<T> const* mixture) const;
-//     [[nodiscard]] T getPermeabilityParameter(const arch::Membrane<T>* membrane) const;
-//     [[nodiscard]] T getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const override;
+    [[nodiscard]] T getPoreResistance(const std::shared_ptr<arch::Membrane<T>>&  membrane, Mixture<T> const* mixture) const;
+    [[nodiscard]] T getPermeabilityParameter(const arch::Membrane<T>* membrane) const;
+    [[nodiscard]] T getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const override;
 
-//     friend class AbstractMembrane<T>;
-// };
+    friend class AbstractMembrane<T>;
+};
 
 /**
  * @brief Class that defines the functionality of the 1D membrane resistance model.

--- a/src/simulation/models/MembraneModels.h
+++ b/src/simulation/models/MembraneModels.h
@@ -51,57 +51,60 @@ public:
 
 };
 
-/**
- * @brief Class that describes the poreResistance membrane model. This membrane model derives the permeability from pore geometry.
-*/
-template<typename T>
-class PermeabilityMembraneModel final : public MembraneModel<T> {
+// /**
+//  * @brief Class that describes the poreResistance membrane model. This membrane model derives the permeability from pore geometry.
+// */
+// template<typename T>
+// class PermeabilityMembraneModel final : public MembraneModel<T> {
 
-private:
+// private:
 
-    /**
-     * @brief Constructor of a poreResistance membrane model.
-    */
-    PermeabilityMembraneModel();
+//     /**
+//      * @brief Constructor of a poreResistance membrane model.
+//     */
+//     PermeabilityMembraneModel();
     
-    friend class AbstractMembrane<T>;
-};
+//     friend class AbstractMembrane<T>;
+// };
 
-/**
- * @brief Class that describes the poreResistance membrane model. This membrane model derives the permeability from pore geometry.
-*/
-template<typename T>
-class PoreResistanceMembraneModel final : public MembraneModel<T> {
+// /**
+//  * @brief Class that describes the poreResistance membrane model. This membrane model derives the permeability from pore geometry.
+// */
+// template<typename T>
+// class PoreResistanceMembraneModel final : public MembraneModel<T> {
 
-private:
+// private:
 
-    /**
-     * @brief Constructor of a poreResistance membrane model.
-    */
-    PoreResistanceMembraneModel();
+//     /**
+//      * @brief Constructor of a poreResistance membrane model.
+//     */
+//     PoreResistanceMembraneModel();
 
-    friend class AbstractMembrane<T>;
+//     friend class AbstractMembrane<T>;
 
-};
+// };
 
+/** TODO: Miscellaneous
+ * Fix Specie/Mixture inconsistency
+ */
 /**
  * @brief Class that defines the functionality of the 1D membrane resistance model.
  * Membrane Resistance Model 0
  * Based on Source: M. Ishahak, J. Hill, Q. Amin, L. Wubker, A. Hernandez, A. Mitrofanova, A. Sloan, A. Fornoni and A. Agarwal. "Modular Microphysiological System for Modeling of Biologic Barrier Function". In: Front. Bioeng. Biotechnol. 8:581163. (2020). doi: 10.3389/fbioe.2020.581163
  */
-template<typename T>
-class MembraneModel0 final : public MembraneModel<T> {
+// template<typename T>
+// class MembraneModel0 final : public MembraneModel<T> {
 
-  private:
+//   private:
 
-    MembraneModel0();
+//     MembraneModel0();
 
-    [[nodiscard]] T getPoreResistance(const std::shared_ptr<arch::Membrane<T>>&  membrane, Mixture<T> const* mixture) const;
-    [[nodiscard]] T getPermeabilityParameter(const arch::Membrane<T>* membrane) const;
-    [[nodiscard]] T getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const override;
+//     [[nodiscard]] T getPoreResistance(const std::shared_ptr<arch::Membrane<T>>&  membrane, Mixture<T> const* mixture) const;
+//     [[nodiscard]] T getPermeabilityParameter(const arch::Membrane<T>* membrane) const;
+//     [[nodiscard]] T getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const override;
 
-    friend class AbstractMembrane<T>;
-};
+//     friend class AbstractMembrane<T>;
+// };
 
 /**
  * @brief Class that defines the functionality of the 1D membrane resistance model.

--- a/src/simulation/models/MembraneModels.hh
+++ b/src/simulation/models/MembraneModels.hh
@@ -5,42 +5,37 @@ namespace sim {
 template<typename T>
 MembraneModel<T>::MembraneModel() { }
 
-//=========================================================================================
-//=============================  permeability Membrane  ===================================
-//=========================================================================================
-
+/** TODO: HybridOocSimulation
+ * Check if a Permeability membrane model is relevant
+ */
 // template<typename T>
 // PermeabilityMembraneModel<T>::PermeabilityMembraneModel() : MembraneModel<T>() { }
 
 
-//=========================================================================================
-//============================  poreResistance Membrane  ==================================
-//=========================================================================================
-
+/** TODO: HybridOocSimulation
+ * Check if a PoreResistance membrane model is relevant
+ */
 // template<typename T>
 // PoreResistanceMembraneModel<T>::PoreResistanceMembraneModel() : MembraneModel<T>() { }
 
-/** TODO: Miscellaneous
- * Fix Species and Mixture inconsistency
- */
 // Ishahak2020
-// template<typename T>
-// MembraneModel0<T>::MembraneModel0() = default;
+template<typename T>
+MembraneModel0<T>::MembraneModel0() = default;
 
-// template<typename T>
-// T MembraneModel0<T>::getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const {
-//     return getPoreResistance(membrane, specie) / (area * membrane->getPorosity());
-// }
+template<typename T>
+T MembraneModel0<T>::getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const {
+    return getPoreResistance(membrane, mixture) / (area * membrane->getPorosity());
+}
 
-// template<typename T>
-// T MembraneModel0<T>::getPermeabilityParameter(const arch::Membrane<T>* const membrane) const {
-//     return (M_PI * membrane->getPorosity() * pow(membrane->getPoreRadius(), 4)) / 8;
-// }
+template<typename T>
+T MembraneModel0<T>::getPermeabilityParameter(const arch::Membrane<T>* const membrane) const {
+    return (M_PI * membrane->getPorosity() * pow(membrane->getPoreRadius(), 4)) / 8;
+}
 
-// template<typename T>
-// T MembraneModel0<T>::getPoreResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture) const {
-//     return (8 * mixture->getViscosity() * membrane->getHeight()) / (M_PI * pow(membrane->getPoreRadius(), 4));
-// }
+template<typename T>
+T MembraneModel0<T>::getPoreResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture) const {
+    return (8 * mixture->getViscosity() * membrane->getHeight()) / (M_PI * pow(membrane->getPoreRadius(), 4));
+}
 
 // VanDersarl2011
 template<typename T>

--- a/src/simulation/models/MembraneModels.hh
+++ b/src/simulation/models/MembraneModels.hh
@@ -9,35 +9,38 @@ MembraneModel<T>::MembraneModel() { }
 //=============================  permeability Membrane  ===================================
 //=========================================================================================
 
-template<typename T>
-PermeabilityMembraneModel<T>::PermeabilityMembraneModel() : MembraneModel<T>() { }
+// template<typename T>
+// PermeabilityMembraneModel<T>::PermeabilityMembraneModel() : MembraneModel<T>() { }
 
 
 //=========================================================================================
 //============================  poreResistance Membrane  ==================================
 //=========================================================================================
 
-template<typename T>
-PoreResistanceMembraneModel<T>::PoreResistanceMembraneModel() : MembraneModel<T>() { }
+// template<typename T>
+// PoreResistanceMembraneModel<T>::PoreResistanceMembraneModel() : MembraneModel<T>() { }
 
+/** TODO: Miscellaneous
+ * Fix Species and Mixture inconsistency
+ */
 // Ishahak2020
-template<typename T>
-MembraneModel0<T>::MembraneModel0() = default;
+// template<typename T>
+// MembraneModel0<T>::MembraneModel0() = default;
 
-template<typename T>
-T MembraneModel0<T>::getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const {
-    return getPoreResistance(membrane, specie) / (area * membrane->getPorosity());
-}
+// template<typename T>
+// T MembraneModel0<T>::getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const {
+//     return getPoreResistance(membrane, specie) / (area * membrane->getPorosity());
+// }
 
-template<typename T>
-T MembraneModel0<T>::getPermeabilityParameter(const arch::Membrane<T>* const membrane) const {
-    return (M_PI * membrane->getPorosity() * pow(membrane->getPoreRadius(), 4)) / 8;
-}
+// template<typename T>
+// T MembraneModel0<T>::getPermeabilityParameter(const arch::Membrane<T>* const membrane) const {
+//     return (M_PI * membrane->getPorosity() * pow(membrane->getPoreRadius(), 4)) / 8;
+// }
 
-template<typename T>
-T MembraneModel0<T>::getPoreResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture) const {
-    return (8 * mixture->getViscosity() * membrane->getHeight()) / (M_PI * pow(membrane->getPoreRadius(), 4));
-}
+// template<typename T>
+// T MembraneModel0<T>::getPoreResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture) const {
+//     return (8 * mixture->getViscosity() * membrane->getHeight()) / (M_PI * pow(membrane->getPoreRadius(), 4));
+// }
 
 // VanDersarl2011
 template<typename T>
@@ -154,7 +157,7 @@ MembraneModel6<T>::MembraneModel6() {}
 template<typename T>
 T MembraneModel6<T>::getMembraneResistance(const std::shared_ptr<arch::Membrane<T>>& membrane, Mixture<T> const* mixture, Specie<T> const* specie, T area) const {
     T diffusionCoefficient = specie->getDiffusivity();
-    return (0.5 * membrane->getChannel()->getHeight() / diffusionCoefficient + membrane->getHeight() / diffusionFactorMembrane + membrane->getTank()->getHeight() * 0.5 / diffusionCoefficient);
+    return (0.5 * membrane->getRectangularChannel()->getHeight() / diffusionCoefficient + membrane->getHeight() / diffusionFactorMembrane + membrane->getTank()->getHeight() * 0.5 / diffusionCoefficient);
 }
 
 // Berg1993, permeability increases twice as fast for small number of N

--- a/src/simulation/models/MixingModels.hh
+++ b/src/simulation/models/MixingModels.hh
@@ -191,11 +191,11 @@ bool InstantaneousMixingModel<T>::updateNodeOutflow(AbstractMixing<T>* sim, std:
     bool updated = false;
     for (auto& [nodeId, mixtureInflowList] : mixtureInflowAtNode) {
         bool createMixture = false;
-        std::unordered_map<size_t, Specie<T>*> speciePtrs;
+        std::unordered_map<size_t, std::shared_ptr<Specie<T>>> speciePtrs;
         std::unordered_map<size_t, T> newConcentrations;
         for (auto& mixtureInflow : mixtureInflowList) {
             for (auto& [specieId, oldConcentration] : tmpMixtures[mixtureInflow.mixtureId].getSpecieConcentrations()) {
-                speciePtrs.try_emplace(specieId, sim->getSpecie(specieId).get());
+                speciePtrs.try_emplace(specieId, sim->getSpecie(specieId));
                 T newConcentration = oldConcentration * mixtureInflow.inflowVolume / totalInflowVolumeAtNode.at(nodeId);
                 auto [iterator, inserted] = newConcentrations.try_emplace(specieId, newConcentration);
                 if (!inserted) {

--- a/src/simulation/operations/Injection.h
+++ b/src/simulation/operations/Injection.h
@@ -40,12 +40,13 @@ class Droplet;
 template<typename T>
 class DropletInjection final {
   private:
-    inline static size_t injectionCounter = 0;       ///< Global counter for amount of created dropletInjection objects.
-    const size_t id;                              ///< Unique identifier of an injection.
-    DropletImplementation<T>* const droplet;      ///< Pointer to droplet to be injected.
-    std::string name = "";                        ///< Name of the injection.
-    T injectionTime = 0.0;                        ///< Time at which the injection should take place in s elapsed since the start of the simulation.
-    arch::ChannelPosition<T> injectionPosition;   ///< Position at which the droplet should be injected.
+    inline static size_t injectionCounter = 0;        ///< Global counter for amount of created dropletInjection objects.
+    const size_t id;                                  ///< Unique identifier of an injection.
+    DropletImplementation<T>* const droplet;          ///< Pointer to droplet to be injected.
+    std::string name = "";                            ///< Name of the injection.
+    T injectionTime = 0.0;                            ///< Time at which the injection should take place in s elapsed since the start of the simulation.
+    arch::ChannelPosition<T> injectionPosition;       ///< Position at which the droplet should be injected.
+    const sim::AbstractDroplet<T>* simRef = nullptr;  ///< Pointer to the simulation in which this injection takes place.
 
     /**
      * @brief A static member function that resets the dropletInjection object counter to zero.
@@ -69,7 +70,7 @@ class DropletInjection final {
      * @param[in] channel Channel in which the droplet should be injected. The channel must be able to fully contain the droplet.
      * @param[in] injectionPosition Relative position (between 0.0 and 1.0) of the middle of the droplet in channel. Head and tail position must be in same channel.
      */
-    DropletInjection(size_t id, DropletImplementation<T>* droplet, T injectionTime, arch::Channel<T>* channel, T injectionPosition);
+    DropletInjection(size_t id, DropletImplementation<T>* droplet, T injectionTime, arch::Channel<T>* channel, T injectionPosition, AbstractDroplet<T>* simRef);
 
     /**
      * @brief Retrieve pointer to the droplet that should be injected.
@@ -113,13 +114,26 @@ class DropletInjection final {
      * @brief Retrieve position at which the injection should take place.
      * @return Position at which the injection should take place. An injection can only take place in channels that are able to fully contain droplet.
      */
-    [[nodiscard]] const arch::ChannelPosition<T>& getInjectionPosition() const { return injectionPosition; }
+    [[nodiscard]] const T getInjectionPosition() const { return injectionPosition.getPosition(); }
+
+    /**
+     * @brief Set the position of the injection
+     * @param[in] position Position of the injection
+     * @note position should be between 0.0 and 1.0
+     */
+    inline void setInjectionPosition(T position);
+
+    /**
+     * @brief Retrieve position at which the injection should take place.
+     * @return Position at which the injection should take place. An injection can only take place in channels that are able to fully contain droplet.
+     */
+    [[nodiscard]] const std::shared_ptr<arch::Channel<T>> getInjectionChannel() const;
 
     /**
      * @brief Set the position of the injection
      * @param[in] position Position of the injection
      */
-    inline void setInjectionPosition(arch::ChannelPosition<T> position) { this->injectionPosition = std::move(position); }
+    inline void setInjectionChannel(const std::shared_ptr<arch::Channel<T>>& channel);
 
     // Friend classes that need access to private member functions
     friend class AbstractDroplet<T>; 

--- a/src/simulation/operations/Injection.h
+++ b/src/simulation/operations/Injection.h
@@ -41,7 +41,7 @@ template<typename T>
 class DropletInjection final {
   private:
     inline static size_t injectionCounter = 0;       ///< Global counter for amount of created dropletInjection objects.
-    const size_t id;                        ///< Unique identifier of an injection.
+    const size_t id;                              ///< Unique identifier of an injection.
     DropletImplementation<T>* const droplet;      ///< Pointer to droplet to be injected.
     std::string name = "";                        ///< Name of the injection.
     T injectionTime = 0.0;                        ///< Time at which the injection should take place in s elapsed since the start of the simulation.

--- a/src/simulation/operations/Injection.h
+++ b/src/simulation/operations/Injection.h
@@ -121,7 +121,7 @@ class DropletInjection final {
      * @param[in] position Position of the injection
      * @note position should be between 0.0 and 1.0
      */
-    inline void setInjectionPosition(T position);
+    void setInjectionPosition(T position);
 
     /**
      * @brief Retrieve position at which the injection should take place.

--- a/src/simulation/operations/Injection.hh
+++ b/src/simulation/operations/Injection.hh
@@ -3,7 +3,26 @@
 namespace sim {
 
 template<typename T>
-DropletInjection<T>::DropletInjection(size_t id, DropletImplementation<T>* droplet, T injectionTime, arch::Channel<T>* channel, T injectionPosition) : 
-    id(id), droplet(droplet), injectionTime(injectionTime), injectionPosition(arch::ChannelPosition<T>(channel, injectionPosition)) { ++injectionCounter; }
+DropletInjection<T>::DropletInjection(size_t id, DropletImplementation<T>* droplet, T injectionTime, arch::Channel<T>* channel, T injectionPosition, AbstractDroplet<T>* simRef) : 
+    id(id), droplet(droplet), injectionTime(injectionTime), injectionPosition(arch::ChannelPosition<T>(channel, injectionPosition)), simRef(simRef) { ++injectionCounter; }
+
+template<typename T>
+void DropletInjection<T>::setInjectionPosition(T position) {
+    if (position < 0.0 || position > 1.0) {
+        throw std::invalid_argument("Injection position should be between 0.0 and 1.0.");
+    }
+    this->injectionPosition.setPosition(position);  
+}
+
+template<typename T>
+const std::shared_ptr<arch::Channel<T>> DropletInjection<T>::getInjectionChannel() const { 
+    return simRef->getNetwork()->getChannel(injectionPosition.getChannel()->getId()); 
+}
+
+template<typename T>
+void DropletInjection<T>::setInjectionChannel(const std::shared_ptr<arch::Channel<T>>& channel) { 
+    simRef->getNetwork()->getChannel(channel->getId()); // check if channel exists in network
+    injectionPosition.setChannel(channel.get()); 
+}
 
 }  // namespace sim

--- a/src/simulation/operations/MixtureInjection.h
+++ b/src/simulation/operations/MixtureInjection.h
@@ -94,6 +94,12 @@ class MixtureInjection final {
      */
     [[nodiscard]] inline const bool wasPerformed() { return performed; }
 
+    /**
+     * @brief Retrieve identification of the mixture that should be injected.
+     * @return MixtureId of the mixture to be injected.
+     */
+    [[nodiscard]] inline size_t getMixtureId() { return mixture->getId(); }
+
   public:
 
     /**
@@ -137,12 +143,6 @@ class MixtureInjection final {
      * @param[in] channel Channel of the injection
      */
     inline void setInjectionChannel(arch::Channel<T>* channel) { this->injectionChannel = channel; }
-
-    /**
-     * @brief Retrieve identification of the mixture that should be injected.
-     * @return MixtureId of the mixture to be injected.
-     */
-    [[nodiscard]] inline size_t getMixtureId() { return mixture->getId(); }
 
     // Friend classes that need access to private member functions
     friend class AbstractMixing<T>;

--- a/src/simulation/operations/MixtureInjection.h
+++ b/src/simulation/operations/MixtureInjection.h
@@ -36,6 +36,9 @@ template<typename T>
 class Mixture;
 
 template<typename T>
+class InstantaneousMixingModel;
+
+template<typename T>
 class MixtureInjectionEvent;
 
 template<typename T>
@@ -146,6 +149,7 @@ class MixtureInjection final {
 
     // Friend classes that need access to private member functions
     friend class AbstractMixing<T>;
+    friend class InstantaneousMixingModel<T>;
     friend class MixtureInjectionEvent<T>;
     friend class PermanentMixtureInjectionEvent<T>;
     friend class test::definitions::GlobalTest<T>;

--- a/src/simulation/simulators/AbstractContinuous.hh
+++ b/src/simulation/simulators/AbstractContinuous.hh
@@ -7,6 +7,7 @@ namespace sim {
 
     template<typename T>
     void AbstractContinuous<T>::simulate() {
+        Simulation<T>::simulate();
         this->assertInitialized();      // perform initialization checks
         this->initialize();             // initialize the simulation
         this->conductNodalAnalysis();   // compute nodal analysis

--- a/src/simulation/simulators/AbstractDroplet.h
+++ b/src/simulation/simulators/AbstractDroplet.h
@@ -198,7 +198,7 @@ public:
      * @param[in] injectionPosition Position inside the channel at which the droplet should be injected (relative to the channel length between 0.0 and 1.0).
      * @return Pointer to created injection.
      */
-    [[maybe_unused]] std::shared_ptr<DropletInjection<T>> addDropletInjection(const std::shared_ptr<Droplet<T>>& droplet, T injectionTime, const std::shared_ptr<arch::RectangularChannel<T>>& channel, T injectionPosition); 
+    [[maybe_unused]] std::shared_ptr<DropletInjection<T>> addDropletInjection(const std::shared_ptr<Droplet<T>>& droplet, T injectionTime, const std::shared_ptr<arch::Channel<T>>& channel, T injectionPosition); 
 
     /**
      * @brief Get injection

--- a/src/simulation/simulators/AbstractDroplet.h
+++ b/src/simulation/simulators/AbstractDroplet.h
@@ -169,9 +169,6 @@ public:
      */
     [[nodiscard]] std::tuple<bool, std::shared_ptr<Droplet<T>>> getDropletAtNode(const std::shared_ptr<arch::Node<T>>& node) const;
 
-    /** TODO: Miscellaneous 
-     * reset the simHash
-    */
     /**
      * @brief Removes the droplet from the simulator. If one or multiple dropletInjections are coupled
      * to the removed droplet, these are also removed from the simulator.
@@ -214,9 +211,6 @@ public:
     */
     void removeDropletInjection(const std::shared_ptr<DropletInjection<T>>& dropletInjection);
 
-    /** TODO: Miscellaneous 
-     * reset the simHash
-     */
     /**
      * @brief In addition to removing the fluid, the droplets that point to the fluid that is to be
      * removed, will be reset to point to the default fluid, i.e., the continuous phase.

--- a/src/simulation/simulators/AbstractDroplet.hh
+++ b/src/simulation/simulators/AbstractDroplet.hh
@@ -142,8 +142,8 @@ namespace sim {
     }
 
     template<typename T>
-    std::shared_ptr<DropletInjection<T>> AbstractDroplet<T>::addDropletInjection(const std::shared_ptr<Droplet<T>>& droplet, T injectionTime, const std::shared_ptr<arch::RectangularChannel<T>>& channel, T injectionPosition) {
-        addDropletInjection(droplet->getId(), injectionTime, channel->getId(), injectionPosition);
+    std::shared_ptr<DropletInjection<T>> AbstractDroplet<T>::addDropletInjection(const std::shared_ptr<Droplet<T>>& droplet, T injectionTime, const std::shared_ptr<arch::Channel<T>>& channel, T injectionPosition) {
+        return addDropletInjection(droplet->getId(), injectionTime, channel->getId(), injectionPosition);
     }
 
     template<typename T>

--- a/src/simulation/simulators/AbstractDroplet.hh
+++ b/src/simulation/simulators/AbstractDroplet.hh
@@ -136,7 +136,7 @@ namespace sim {
             throw std::invalid_argument("Injection of droplet " + droplet->getName() + " is not valid. Tail and head of the droplet must lie inside the channel " + std::to_string(channel->getId()) + ". Consider to set the injection position in the middle of the channel.");
         }
 
-        auto result = dropletInjections.try_emplace(id, std::shared_ptr<DropletInjection<T>>(new DropletInjection<T>(id, droplet, injectionTime, channel.get(), injectionPosition)));
+        auto result = dropletInjections.try_emplace(id, std::shared_ptr<DropletInjection<T>>(new DropletInjection<T>(id, droplet, injectionTime, channel.get(), injectionPosition, this)));
         if (result.second) { injectionMapInsertion(dropletId, id); }
         return result.first->second;
     }
@@ -170,7 +170,7 @@ namespace sim {
             // Check if droplets are pointing to the fluid that is to be removed
             if (droplet->readFluid()->getId() == fluid->getId()) {
                 // Set the droplet's fluid to default, i.e., continuous phase
-                droplet->setFluid(this->getContinuousPhase().get());
+                droplet->setFluid(this->getContinuousPhase());
             } 
         }
 

--- a/src/simulation/simulators/AbstractDroplet.hh
+++ b/src/simulation/simulators/AbstractDroplet.hh
@@ -365,6 +365,7 @@ namespace sim {
 
     template<typename T>
     void AbstractDroplet<T>::simulate() {
+        Simulation<T>::simulate();
         this->assertInitialized();              // perform initialization checks
         this->initialize();                     // initialize the simulation
         while (true) {

--- a/src/simulation/simulators/AbstractMembrane.h
+++ b/src/simulation/simulators/AbstractMembrane.h
@@ -48,23 +48,26 @@ public:
     /** 
      * @brief Set the permeability membrane model to be used in the simulation.
      */
-    void setPermeabilityMembraneModel() {
-        this->membraneModel = std::unique_ptr<PermeabilityMembraneModel<T>>(new PermeabilityMembraneModel<T>());
-    }
+    // void setPermeabilityMembraneModel() {
+    //     this->membraneModel = std::unique_ptr<PermeabilityMembraneModel<T>>(new PermeabilityMembraneModel<T>());
+    // }
 
     /**
      * @brief Set the pore resistance membrane model to be used in the simulation.
      */
-    void setPoreResistanceMembraneModel() {
-        this->membraneModel = std::unique_ptr<PoreResistanceMembraneModel<T>>(new PoreResistanceMembraneModel<T>());
-    }
+    // void setPoreResistanceMembraneModel() {
+    //     this->membraneModel = std::unique_ptr<PoreResistanceMembraneModel<T>>(new PoreResistanceMembraneModel<T>());
+    // }
 
+    /** TODO: Miscellaneous
+     * Fix Specie/Mixture inconsistency
+     */
     /**
      * @brief Set the membrane model 0 to be used in the simulation.
      */
-    void setMembraneModel0() {
-        this->membraneModel = std::unique_ptr<MembraneModel0<T>>(new MembraneModel0<T>());
-    }
+    // void setMembraneModel0() {
+    //     this->membraneModel = std::unique_ptr<MembraneModel0<T>>(new MembraneModel0<T>());
+    // }
 
     /**
      * @brief Set the membrane model 1 to be used in the simulation.
@@ -83,7 +86,7 @@ public:
     /**
      * @brief Set the membrane model 3 to be used in the simulation.
      */
-    void setMebraneModel3() {
+    void setMembraneModel3() {
         this->membraneModel = std::unique_ptr<MembraneModel3<T>>(new MembraneModel3<T>());
     }
 

--- a/src/simulation/simulators/AbstractMembrane.h
+++ b/src/simulation/simulators/AbstractMembrane.h
@@ -45,6 +45,9 @@ public:
      */
     AbstractMembrane(std::shared_ptr<arch::Network<T>> network);
 
+    /** TODO: HybridOocSimulation
+     * Check if a Permeability membrane model is relevant
+     */
     /** 
      * @brief Set the permeability membrane model to be used in the simulation.
      */
@@ -52,6 +55,9 @@ public:
     //     this->membraneModel = std::unique_ptr<PermeabilityMembraneModel<T>>(new PermeabilityMembraneModel<T>());
     // }
 
+    /** TODO: HybridOocSimulation
+     * Check if a PoreResistance membrane model is relevant
+     */
     /**
      * @brief Set the pore resistance membrane model to be used in the simulation.
      */
@@ -59,15 +65,12 @@ public:
     //     this->membraneModel = std::unique_ptr<PoreResistanceMembraneModel<T>>(new PoreResistanceMembraneModel<T>());
     // }
 
-    /** TODO: Miscellaneous
-     * Fix Specie/Mixture inconsistency
-     */
     /**
      * @brief Set the membrane model 0 to be used in the simulation.
      */
-    // void setMembraneModel0() {
-    //     this->membraneModel = std::unique_ptr<MembraneModel0<T>>(new MembraneModel0<T>());
-    // }
+    void setMembraneModel0() {
+        this->membraneModel = std::unique_ptr<MembraneModel0<T>>(new MembraneModel0<T>());
+    }
 
     /**
      * @brief Set the membrane model 1 to be used in the simulation.

--- a/src/simulation/simulators/AbstractMembrane.hh
+++ b/src/simulation/simulators/AbstractMembrane.hh
@@ -4,7 +4,8 @@ namespace sim {
 
     template<typename T>
     AbstractMembrane<T>::AbstractMembrane(std::shared_ptr<arch::Network<T>> network) : AbstractMixing<T>(Type::Abstract, Platform::Membrane, network) {
-        membraneModel = std::unique_ptr<MembraneModel9<T>>(new MembraneModel9<T>());
+        // Default membrane model upon construction
+        this->setMembraneModel9();
     }
 
     template<typename T>

--- a/src/simulation/simulators/AbstractMembrane.hh
+++ b/src/simulation/simulators/AbstractMembrane.hh
@@ -17,6 +17,7 @@ namespace sim {
 
     template<typename T>
     void AbstractMembrane<T>::simulate() {
+        Simulation<T>::simulate();
         this->assertInitialized();              // perform initialization checks
         this->initialize();                     // initialize the simulation
         

--- a/src/simulation/simulators/AbstractMixing.h
+++ b/src/simulation/simulators/AbstractMixing.h
@@ -101,7 +101,7 @@ protected:
      * @param[in] specieConcentrations unordered map of specie id and corresponding concentration.
      * @return Pointer to created mixture.
      */
-    Mixture<T>* addMixture(std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations);
+    Mixture<T>* addMixture(std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations);
 
     /**
      * @brief Create mixture.
@@ -116,7 +116,7 @@ protected:
      * @param[in] specieConcentrations
      * @return Pointer to created mixture.
      */
-    Mixture<T>* addDiffusiveMixture(std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations);
+    Mixture<T>* addDiffusiveMixture(std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations);
 
     /**
      * @brief Create mixture.
@@ -179,7 +179,7 @@ protected:
 
     /**
      * @brief Remove specie from the simulator. If a mixture contains the specie, it is removed from the mixture as well.
-     * A mixture consisting of a single specie is removed from the simulation.
+     * A mixture consisting of a single specie that is removed, will be removed from the simulation as well.
      * @param[in] specieId Id of the specie that should be removed.
      * @throws std::logic_error if the specie is not present in the simulation.
      */

--- a/src/simulation/simulators/AbstractMixing.h
+++ b/src/simulation/simulators/AbstractMixing.h
@@ -183,7 +183,7 @@ protected:
      * @param[in] specieId Id of the specie that should be removed.
      * @throws std::logic_error if the specie is not present in the simulation.
      */
-    void removeSpecie(int specieId);
+    void removeSpecie(size_t specieId);
 
     /**
      * @brief Remove mixture from the simulation.
@@ -191,14 +191,14 @@ protected:
      * @throws std::logic_error if the mixture is not present in the simulation.
      * @note If the mixture is present in the simulation, it is removed from the simulation.
      */
-    void removeMixture(int mixtureId);
+    void removeMixture(size_t mixtureId);
 
     /**
      * @brief Remove mixture injection from the simulation.
      * @param[in] injectionId Id of the mixture injection that should be removed.
      * @throws std::logic_error if the injection is not present in the simulation.
      */
-    void removeMixtureInjection(int mixtureInjectionId);
+    void removeMixtureInjection(size_t mixtureInjectionId);
 
 public:
     /**

--- a/src/simulation/simulators/AbstractMixing.hh
+++ b/src/simulation/simulators/AbstractMixing.hh
@@ -58,7 +58,7 @@ namespace sim {
                     if (mixture->getSpecieCount() == 1) {
                         removeMixture(mixtureId);
                     } else {
-                        mixture->removeSpecie(speciePtr);
+                        mixture->forceRemoveSpecie(speciePtr);
                     }
                 }
             } 
@@ -85,10 +85,10 @@ namespace sim {
             throw std::invalid_argument("At least one species must be present in a mixture.");
         }
         // Transform the vector of species and concentrations into an unordered_map
-        std::unordered_map<size_t, Specie<T>*> speciesMap;
+        std::unordered_map<size_t, std::shared_ptr<Specie<T>>> speciesMap;
         std::unordered_map<size_t, T> specieConcentrationsMap;
         for (size_t i = 0; i < speciesVec.size(); ++i) {
-            speciesMap.try_emplace(speciesVec[i]->getId(), speciesVec[i].get());
+            speciesMap.try_emplace(speciesVec[i]->getId(), speciesVec[i]);
             specieConcentrationsMap.try_emplace(speciesVec[i]->getId(), concentrations[i]);
         }
 
@@ -105,10 +105,10 @@ namespace sim {
         Fluid<T>* carrierFluid = this->getContinuousPhase().get();
 
         // Transform the vector of species and concentrations into an unordered_map
-        std::unordered_map<size_t, Specie<T>*> speciesMap;
+        std::unordered_map<size_t, std::shared_ptr<Specie<T>>> speciesMap;
         std::unordered_map<size_t, T> specieConcentrationsMap(std::move(specieConcentrations_));
         for (auto& [key, conc] : specieConcentrationsMap) {
-            speciesMap.try_emplace(key, species.at(key).get());
+            speciesMap.try_emplace(key, species.at(key));
         }
 
         // Create non-mutable Mixture
@@ -355,10 +355,10 @@ namespace sim {
     Mixture<T>* AbstractMixing<T>::addMixture(std::unordered_map<size_t, T> specieConcentrations) {
         size_t id = Mixture<T>::getMixtureCounter();
 
-        std::unordered_map<size_t, Specie<T>*> species;
+        std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species;
 
         for (auto& [specieId, concentration] : specieConcentrations) {
-            species.try_emplace(specieId, getSpecie(specieId).get());
+            species.try_emplace(specieId, getSpecie(specieId));
         }
 
         Fluid<T>* carrierFluid = this->getContinuousPhase().get();
@@ -370,7 +370,7 @@ namespace sim {
     }
 
     template<typename T>
-    Mixture<T>* AbstractMixing<T>::addMixture(std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations) {
+    Mixture<T>* AbstractMixing<T>::addMixture(std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations) {
         size_t id = Mixture<T>::getMixtureCounter();
 
         Fluid<T>* carrierFluid = this->getContinuousPhase().get();
@@ -404,7 +404,7 @@ namespace sim {
     }
 
     template<typename T>
-    Mixture<T>* AbstractMixing<T>::addDiffusiveMixture(std::unordered_map<size_t, Specie<T>*> species, std::unordered_map<size_t, T> specieConcentrations) {
+    Mixture<T>* AbstractMixing<T>::addDiffusiveMixture(std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species, std::unordered_map<size_t, T> specieConcentrations) {
         size_t id = Mixture<T>::getMixtureCounter();
 
         std::unordered_map<size_t, std::tuple<std::function<T(T)>, std::vector<T>,T>> specieDistributions;
@@ -427,11 +427,11 @@ namespace sim {
     Mixture<T>* AbstractMixing<T>::addDiffusiveMixture(std::unordered_map<size_t, std::tuple<std::function<T(T)>, std::vector<T>,T>> specieDistributions) {
         size_t id = Mixture<T>::getMixtureCounter();
 
-        std::unordered_map<size_t, Specie<T>*> species;
+        std::unordered_map<size_t, std::shared_ptr<Specie<T>>> species;
         std::unordered_map<size_t, T> specieConcentrations;
 
         for (auto& [specieId, distribution] : specieDistributions) {
-            species.try_emplace(specieId, getSpecie(specieId).get());
+            species.try_emplace(specieId, getSpecie(specieId));
             specieConcentrations.try_emplace(specieId, T(0));
         }
 

--- a/src/simulation/simulators/AbstractMixing.hh
+++ b/src/simulation/simulators/AbstractMixing.hh
@@ -45,10 +45,11 @@ namespace sim {
     }
 
     template<typename T>
-    void AbstractMixing<T>::removeSpecie(int specieId) {
-        auto& it = species.find(specieId);
+    void AbstractMixing<T>::removeSpecie(size_t specieId) {
+        auto it = species.find(specieId);
         if (it != species.end()) {
-            it->second->resetHash();  // Reset the hash of the specie to avoid dangling references
+            auto speciePtr = it->second;
+            speciePtr->resetHash();  // Reset the hash of the specie to avoid dangling references
             // Remove the specie from the species map
             // and remove it from all mixtures that contain it.
             if (species.erase(specieId)) {
@@ -57,7 +58,7 @@ namespace sim {
                     if (mixture->getSpecieCount() == 1) {
                         removeMixture(mixtureId);
                     } else {
-                        mixture->removeSpecie(specieId);
+                        mixture->removeSpecie(speciePtr);
                     }
                 }
             } 
@@ -126,8 +127,8 @@ namespace sim {
     }
 
     template<typename T>
-    void AbstractMixing<T>::removeMixture(int mixtureId) {
-        auto& it = mixtures.find(mixtureId);
+    void AbstractMixing<T>::removeMixture(size_t mixtureId) {
+        auto it = mixtures.find(mixtureId);
         if (it != mixtures.end()) {
             it->second->resetHash();  // Reset the hash of the mixture to avoid dangling references
             if (mixtures.erase(mixtureId)) {
@@ -242,10 +243,10 @@ namespace sim {
     }
 
     template<typename T>
-    void AbstractMixing<T>::removeMixtureInjection(int mixtureInjectionId) {
+    void AbstractMixing<T>::removeMixtureInjection(size_t mixtureInjectionId) {
         // This function removes the injectionId from the injectionMap for the given mixtureId
         // If the injectionMap for the mixtureId becomes empty, it removes the mixtureId from the injectionMap
-        auto updateMap = [this, mixtureInjectionId](int mixtureId) {
+        auto updateMap = [this, mixtureInjectionId](size_t mixtureId) {
             injectionMap.at(mixtureId).erase(mixtureInjectionId);
             if (injectionMap.at(mixtureId).empty()) { injectionMap.erase(mixtureId); }
         };

--- a/src/simulation/simulators/AbstractMixing.hh
+++ b/src/simulation/simulators/AbstractMixing.hh
@@ -277,6 +277,7 @@ namespace sim {
 
     template<typename T>
     void AbstractMixing<T>::simulate() {
+        Simulation<T>::simulate();
         this->assertInitialized();      // perform initialization checks
         this->initialize();             // initialize the simulation
         this->conductNodalAnalysis();   // compute nodal analysis

--- a/src/simulation/simulators/HybridContinuous.h
+++ b/src/simulation/simulators/HybridContinuous.h
@@ -161,7 +161,7 @@ public:
      * @brief Create and add an LBM Simulator for a CFD Module to the Hybrid simulation
      * @param[in] module A pointer to the CfdModule on which this simulator instance will conduct LBM simulations.
      * @param[in] resolution The number of grid cells across the characteristic length.
-     * @param[in] epsilon The allowed error margin between this hybrid domain and the abstract domain in TODO.
+     * @param[in] epsilon The allowed error margin between this hybrid domain and the surrounding abstract domain.
      * @param[in] tau The relaxation number of this LBM solver.
      * @param[in] charPhysLength The physical characteristic length of this LBM solver.
      * @param[in] charPhysVelocity The physical characteristic velocity of this LBM solver.

--- a/src/simulation/simulators/HybridContinuous.hh
+++ b/src/simulation/simulators/HybridContinuous.hh
@@ -269,6 +269,7 @@ void HybridContinuous<T>::initialize() {
 
 template<typename T>
 void HybridContinuous<T>::simulate() {
+    Simulation<T>::simulate();
     this->assertInitialized();              // perform initialization checks
     this->initialize();                     // initialize the simulation
     // Catch runtime error, not enough CFD simulators.

--- a/src/simulation/simulators/Simulation.h
+++ b/src/simulation/simulators/Simulation.h
@@ -364,7 +364,7 @@ public:
      * @brief Conduct the simulation.
      * @return The result of the simulation containing all intermediate simulation steps and calculated parameters.
      */
-    virtual void simulate() = 0;
+    virtual void simulate();
 
     /**
      * @brief Mandatory virtual destructor is set to default.

--- a/src/simulation/simulators/Simulation.h
+++ b/src/simulation/simulators/Simulation.h
@@ -153,6 +153,16 @@ protected:
     inline void setFluids(std::unordered_map<size_t, std::shared_ptr<Fluid<T>>> fluids) { this->fluids = std::move(fluids); }
 
     /**
+     * @brief Creates and adds a new fluid out of two existing fluids.
+     * @param fluid0Id Id of the first fluid.
+     * @param volume0 The volume of the first fluid.
+     * @param fluid1Id Id of the second fluid.
+     * @param volume1 The volume of the second fluid.
+     * @return Pointer to new fluid.
+     */
+    std::shared_ptr<Fluid<T>> addMixedFluid(int fluid0Id, T volume0, int fluid1Id, T volume1);
+
+    /**
      * @brief Get fluid.
      * @param[in] fluidId Id of the fluid
      * @return Pointer to fluid with the corresponding id
@@ -235,16 +245,6 @@ public:
 
     /**
      * @brief Creates and adds a new fluid out of two existing fluids.
-     * @param fluid0Id Id of the first fluid.
-     * @param volume0 The volume of the first fluid.
-     * @param fluid1Id Id of the second fluid.
-     * @param volume1 The volume of the second fluid.
-     * @return Pointer to new fluid.
-     */
-    std::shared_ptr<Fluid<T>> addMixedFluid(int fluid0Id, T volume0, int fluid1Id, T volume1);
-
-    /**
-     * @brief Creates and adds a new fluid out of two existing fluids.
      * @param fluid0 Pointer to the first fluid.
      * @param volume0 The volume of the first fluid.
      * @param fluid1 Pointer to the second fluid.
@@ -267,9 +267,6 @@ public:
      */
     [[nodiscard]] const std::unordered_map<size_t, const Fluid<T>*> readFluids() const;
 
-    /** TODO: Miscellaneous
-     * reset the simHash
-     */
     /**
      * @brief Removes a fluid from the simulation, based using the fluid ptr. 
      * @param[in] fluid Pointer to the fluid that is to be removed

--- a/src/simulation/simulators/Simulation.h
+++ b/src/simulation/simulators/Simulation.h
@@ -278,7 +278,7 @@ public:
     virtual void removeFluid(const std::shared_ptr<Fluid<T>>& fluid);
 
     /**
-     * @brief Set the type of the simulation.
+     * @brief Get the fixture id.
      * @param[in] type
      */
     [[nodiscard]] inline int getFixtureId() const { return this->fixtureId; }

--- a/src/simulation/simulators/Simulation.hh
+++ b/src/simulation/simulators/Simulation.hh
@@ -187,4 +187,11 @@ namespace sim {
         nodalAnalysis = std::make_shared<nodal::NodalAnalysis<T>> (network.get());
     }
 
+    template<typename T>
+    void Simulation<T>::simulate() {
+        // Perform common simulation steps
+        network->sortGroups();             // Sort groups in the network
+        network->isNetworkValid();         // Check if the network is valid
+    }
+
 }   /// namespace sim

--- a/src/simulation/simulators/cfdHandlers/cfdSimulator.h
+++ b/src/simulation/simulators/cfdHandlers/cfdSimulator.h
@@ -207,19 +207,19 @@ public:
     [[nodiscard]] inline std::shared_ptr<arch::CfdModule<T>> getModule() const { return cfdModule; }
 
     /**
-     * @brief Get the ground nodes of the module.
+     * @brief Returns whether boundary nodes communicate the pressure (true) or flow rates (false) to the 1D solver.
      * @returns Ground nodes.
     */
     [[nodiscard]] inline const std::unordered_map<size_t, bool>& getGroundNodes() { return groundNodes; }
 
     /**
-     * @brief Returns whether the module is initialized or not.
+     * @brief Returns whether the simulator is initialized or not.
      * @returns Boolean for initialization.
     */
     [[nodiscard]] inline bool getInitialized() const { return initialized; }
 
     /**
-     * @brief Set the initialized status for this module.
+     * @brief Set the initialized status for this simulator.
      * @param[in] initialization Boolean for initialization status.
     */
     inline void setInitialized(bool initialization) { this->initialized = initialization; }

--- a/src/simulation/simulators/cfdHandlers/cfdSimulator.h
+++ b/src/simulation/simulators/cfdHandlers/cfdSimulator.h
@@ -110,16 +110,31 @@ protected:
     virtual void lbmInit(T dynViscosity, T density) = 0;
 
     /**
+     * @brief Returns whether the simulator is initialized or not.
+     * @returns Boolean for initialization.
+    */
+    [[nodiscard]] inline bool getInitialized() const { return initialized; }
+
+    /**
+     * @brief Set the initialized status for this simulator.
+     * @param[in] initialization Boolean for initialization status.
+    */
+    inline void setInitialized(bool initialization) { this->initialized = initialization; }
+
+    /**
      * @brief Conducts the collide and stream operations of the lattice.
     */
     virtual void solve() = 0;
 
-    /** TODO: Miscellaneous */
-    virtual void storePressures(std::unordered_map<size_t, T> pressure) = 0;
-
     /**
      * @brief Store the abstract pressures at the nodes on the module boundary in the simulator.
      * @param[in] pressure Map of pressures and node ids.
+     */
+    virtual void storePressures(std::unordered_map<size_t, T> pressure) = 0;
+
+    /**
+     * @brief Get the pressures at the boundary nodes.
+     * @returns Pressures in Pa.
      */
     virtual const std::unordered_map<size_t, T>& getPressures() const = 0;
 
@@ -134,6 +149,25 @@ protected:
      * @returns Flow rates in m^3/s.
      */
     virtual const std::unordered_map<size_t, T>& getFlowRates() const = 0;
+
+    /**
+     * @brief Store the abstract concentrations at the nodes on the module boundary in the simulator.
+     * @param[in] concentrations Map of concentrations and node ids.
+     */
+    virtual void storeConcentrations(std::unordered_map<int, std::unordered_map<int, T>> concentrations) 
+    {
+        throw std::runtime_error("The function storeConcentrations is undefined for this CFD simulator.");
+    }
+
+    /**
+     * @brief Get the concentrations at the boundary nodes.
+     * @returns Concentrations
+     */
+    virtual std::unordered_map<int, std::unordered_map<int, T>> getConcentrations() const 
+    { 
+        throw std::runtime_error("The function storeConcentrations is undefined for this CFD simulator.");
+        return std::unordered_map<int, std::unordered_map<int, T>>(); 
+    }
 
     /**
      * @brief Returns whether the module has converged or not.
@@ -164,6 +198,12 @@ protected:
     }
 
     /**
+     * @brief Set the boundary values on the lattice at the module nodes.
+     * @param[in] iT Iteration step.
+    */
+    virtual void setBoundaryValues(int iT) = 0;
+
+    /**
      * @brief Conducts the collide and stream operations of the NS lattice.
     */
     virtual void nsSolve() 
@@ -177,6 +217,15 @@ protected:
     virtual void adSolve() 
     {
         throw std::runtime_error("The function adSolve is undefined for this CFD simulator.");
+    }
+
+    /**
+     * @brief Update the values at the module nodes based on the simulation result after stepIter iterations.
+     * @param[in] iT Iteration step.
+    */
+    virtual void storeCfdResults (int iT) 
+    {
+        throw std::runtime_error("The function storeCfdResults is undefined for this CFD simulator.");
     }
 
     /**
@@ -213,18 +262,6 @@ public:
     [[nodiscard]] inline const std::unordered_map<size_t, bool>& getGroundNodes() { return groundNodes; }
 
     /**
-     * @brief Returns whether the simulator is initialized or not.
-     * @returns Boolean for initialization.
-    */
-    [[nodiscard]] inline bool getInitialized() const { return initialized; }
-
-    /**
-     * @brief Set the initialized status for this simulator.
-     * @param[in] initialization Boolean for initialization status.
-    */
-    inline void setInitialized(bool initialization) { this->initialized = initialization; }
-
-    /**
      * @brief Set the path, where vtk output from the simulator should be stored.
      * @param[in] vtkFolder A string containing the path to the vtk folder.
      */
@@ -247,31 +284,6 @@ public:
      * @returns beta.
     */
     [[nodiscard]] inline T getBeta(size_t nodeId) const {return updateScheme->getBeta(nodeId);}
-
-    /**
-     * @brief Store the abstract concentrations at the nodes on the module boundary in the simulator.
-     * @param[in] concentrations Map of concentrations and node ids.
-     */
-    virtual void storeConcentrations(std::unordered_map<int, std::unordered_map<int, T>> concentrations) 
-    {
-        throw std::runtime_error("The function storeConcentrations is undefined for this CFD simulator.");
-    }
-
-    /**
-     * @brief Get the concentrations at the boundary nodes.
-     * @returns Concentrations
-     */
-    virtual std::unordered_map<int, std::unordered_map<int, T>> getConcentrations() const 
-    { 
-        throw std::runtime_error("The function storeConcentrations is undefined for this CFD simulator.");
-        return std::unordered_map<int, std::unordered_map<int, T>>(); 
-    }
-
-    /**
-     * @brief Set the boundary values on the lattice at the module nodes.
-     * @param[in] iT Iteration step.
-    */
-    virtual void setBoundaryValues(int iT) = 0;
 
     /**
      * @brief Write the vtk file with results of the CFD simulation to file system.
@@ -320,15 +332,6 @@ public:
     virtual std::tuple<T, T> getVelocityBounds()
     {
         throw std::runtime_error("The function getVelocityBounds is undefined for this CFD simulator.");
-    }
-
-    /**
-     * @brief Update the values at the module nodes based on the simulation result after stepIter iterations.
-     * @param[in] iT Iteration step.
-    */
-    virtual void storeCfdResults (int iT) 
-    {
-        throw std::runtime_error("The function storeCfdResults is undefined for this CFD simulator.");
     }
 
     friend bool conductCFDSimulation<T>(const std::unordered_map<int, std::shared_ptr<CFDSimulator<T>>>& cfdSimulators);

--- a/src/simulation/simulators/cfdHandlers/olbContinuous.h
+++ b/src/simulation/simulators/cfdHandlers/olbContinuous.h
@@ -305,8 +305,8 @@ public:
     [[nodiscard]] inline int getStepIter() const { return stepIter; }
 
     /**
-     * @brief Returns whether the module has converged or not.
-     * @returns Boolean for module convergence.
+     * @brief Returns whether the simulator has converged or not.
+     * @returns Boolean for simulator convergence.
     */
     [[nodiscard]] inline bool hasConverged() const { return converge->hasConverged(); }
 

--- a/src/simulation/simulators/cfdHandlers/olbMixing.hh
+++ b/src/simulation/simulators/cfdHandlers/olbMixing.hh
@@ -11,8 +11,6 @@ lbmMixingSimulator<T>::lbmMixingSimulator (
         lbmSimulator<T>(id_, name_, stlFile_, cfdModule_, openings_, resistanceModel_, charPhysLength_, charPhysVelocity_, resolution_, epsilon_, relaxationTime_), 
         species(species_), adRelaxationTime(adRelaxationTime_)
 {   
-    std::cout << "Creating module and setting its type to lbm" << std::endl;
-    this->cfdModule->setModuleTypeLbm();
     fluxWall.try_emplace(int(0), &zeroFlux);
 } 
 

--- a/src/simulation/simulators/cfdHandlers/olbOoc.hh
+++ b/src/simulation/simulators/cfdHandlers/olbOoc.hh
@@ -12,7 +12,6 @@ lbmOocSimulator<T>::lbmOocSimulator (
                               resolution_, epsilon_, relaxationTime_, adRelaxationTime_), 
         tissue(tissue_), organStlFile(organStlFile_) 
 {
-    this->cfdModule->setModuleTypeLbm();
     this->fluxWall.try_emplace(int(0), &this->zeroFlux);
 } 
 

--- a/tests/abstract/Architecture.test.cpp
+++ b/tests/abstract/Architecture.test.cpp
@@ -1,10 +1,13 @@
 #include "../src/baseSimulator.h"
 
 #include "gtest/gtest.h"
+#include "../test_definitions.h"
 
 using T = double;
 
-TEST(Network, testNetwork1) {
+class Network : public test::definitions::GlobalTest<T> {};
+
+TEST_F(Network, testNetwork1) {
     // define network
     auto network = arch::Network<T>::createNetwork();
     // nodes
@@ -31,7 +34,7 @@ TEST(Network, testNetwork1) {
     network->setGround(node0->getId());
 
     // compute network
-    network->sortGroups();
+    this->sortGroups(network);
     nodal::NodalAnalysis<T> nodalAnalysis(network.get());
     nodalAnalysis.conductNodalAnalysis();
 
@@ -46,7 +49,7 @@ TEST(Network, testNetwork1) {
     EXPECT_NEAR(v0->getFlowRate(), -0.2 / 3.0, errorTolerance);
 }
 
-TEST(Network, testNetwork2) {
+TEST_F(Network, testNetwork2) {
     // define network
     auto network = arch::Network<T>::createNetwork();
     // nodes
@@ -71,7 +74,7 @@ TEST(Network, testNetwork2) {
     network->addRectangularChannel(node3->getId(), node4->getId(), 30, arch::ChannelType::NORMAL);
 
     // compute network
-    network->sortGroups();
+    this->sortGroups(network);
     nodal::NodalAnalysis<T> nodalAnalysis(network.get());
     nodalAnalysis.conductNodalAnalysis();
 
@@ -88,7 +91,7 @@ TEST(Network, testNetwork2) {
     EXPECT_NEAR(v1->getFlowRate(), 0.0, errorTolerance);
 }
 
-TEST(Network, testNetwork3) {
+TEST_F(Network, testNetwork3) {
     // define network
     auto network = arch::Network<T>::createNetwork();
     // nodes
@@ -109,7 +112,7 @@ TEST(Network, testNetwork3) {
     network->addRectangularChannel(node2->getId(), node0->getId(), 8, arch::ChannelType::NORMAL);
 
     // compute network
-    network->sortGroups();
+    this->sortGroups(network);
     nodal::NodalAnalysis<T> nodalAnalysis(network.get());
     nodalAnalysis.conductNodalAnalysis();
 
@@ -124,7 +127,7 @@ TEST(Network, testNetwork3) {
     EXPECT_NEAR(v1->getFlowRate(), 1.0, errorTolerance);
 }
 
-TEST(Network, testNetwork4) {
+TEST_F(Network, testNetwork4) {
     // define network
     auto network = arch::Network<T>::createNetwork();
     // nodes
@@ -144,7 +147,7 @@ TEST(Network, testNetwork4) {
     network->addRectangularChannel(node2->getId(), node0->getId(), 8, arch::ChannelType::NORMAL);
 
     // compute network
-    network->sortGroups();
+    this->sortGroups(network);
     nodal::NodalAnalysis<T> nodalAnalysis(network.get());
     nodalAnalysis.conductNodalAnalysis();
 
@@ -157,7 +160,7 @@ TEST(Network, testNetwork4) {
     EXPECT_NEAR(v0->getFlowRate(), -7.2, errorTolerance);
 }
 
-TEST(Network, testNetwork5) {
+TEST_F(Network, testNetwork5) {
     // define network
     auto network = arch::Network<T>::createNetwork();
     // nodes
@@ -178,7 +181,7 @@ TEST(Network, testNetwork5) {
     network->addRectangularChannel(node2->getId(), node0->getId(), 10, arch::ChannelType::NORMAL);
 
     // compute network
-    network->sortGroups();
+    this->sortGroups(network);
     nodal::NodalAnalysis<T> nodalAnalysis(network.get());
     nodalAnalysis.conductNodalAnalysis();
 
@@ -190,7 +193,7 @@ TEST(Network, testNetwork5) {
     EXPECT_NEAR(node3->getPressure(), -35.5, errorTolerance);
 }
 
-TEST(Network, networkArchitectureDefinition) {
+TEST_F(Network, networkArchitectureDefinition) {
     // define network
     auto bionetwork = arch::Network<T>::createNetwork();
     auto node1 = bionetwork->addNode(0.0, 0.0, false);

--- a/tests/abstract/BigDroplet.test.cpp
+++ b/tests/abstract/BigDroplet.test.cpp
@@ -60,10 +60,6 @@ TEST_F(BigDroplet, allResultValues) {
     // Set the resistance model
     testSimulation.set1DResistanceModel();
 
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     testSimulation.simulate();
 
@@ -329,10 +325,6 @@ TEST_F(BigDroplet, inverseDirectionChannels) {
     // Set the resistance model
     testSimulation.set1DResistanceModel();
 
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     testSimulation.simulate();
 
@@ -537,10 +529,6 @@ TEST_F(BigDroplet, mixedDirectionChannels) {
     // Set the resistance model
     testSimulation.set1DResistanceModel();
 
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     testSimulation.simulate();
 
@@ -703,9 +691,6 @@ TEST_F(BigDroplet, jsonDefinition) {
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-   
-    network->sortGroups();
-    network->isNetworkValid();
 
     // Perform simulation and store results
     testSimulation->simulate();
@@ -902,10 +887,6 @@ TEST_F(BigDroplet, noSink1) {
     // Set the resistance model
     testSimulation.set1DResistanceModel();
 
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     testSimulation.simulate();
 }
@@ -950,10 +931,6 @@ TEST_F(BigDroplet, noSink2) {
 
     // Set the resistance model
     testSimulation.set1DResistanceModel();
-
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     testSimulation.simulate();
@@ -1000,10 +977,6 @@ TEST_F(BigDroplet, noSinkTwoDroplets) {
 
     // Set the resistance model
     testSimulation.set1DResistanceModel();
-
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     testSimulation.simulate();
@@ -1162,7 +1135,6 @@ TEST_F(BigDroplet, RingNetworkE1) {
   network->setGround(groundNode->getId());
 
   EXPECT_TRUE(network->isNetworkValid());
-  network->sortGroups();
 
   // fluids
   auto fluid0 = sim.addFluid(1e-3, 1e3 /*, molecular size: 9e-10*/);
@@ -1381,7 +1353,6 @@ TEST_F(BigDroplet, RingNetworkE2) {
   network->setGround(groundNode->getId());
 
   EXPECT_TRUE(network->isNetworkValid());
-  network->sortGroups();
 
   // fluids
   auto fluid0 = sim.addFluid(1e-3, 1e3 /*, molecular size: 9e-10*/);

--- a/tests/abstract/Continuous.test.cpp
+++ b/tests/abstract/Continuous.test.cpp
@@ -49,10 +49,6 @@ TEST_F(Continuous, allResultValues) {
     // Set the resistance model
     testSimulation.set1DResistanceModel();
 
-    // check if chip is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     testSimulation.simulate();
 
@@ -88,9 +84,6 @@ TEST_F(Continuous, jsonDefinition) {
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-   
-    network->sortGroups();
-    network->isNetworkValid();
 
     // Perform simulation and store results
     testSimulation->simulate();
@@ -165,12 +158,6 @@ TEST_F(Continuous, triangleNetwork) {
     // Set the resistance model
     testSimulation1.set1DResistanceModel();
     testSimulation2.set1DResistanceModel();
-
-    // check if chips are valid
-    network1->isNetworkValid();
-    network2->isNetworkValid();
-    network1->sortGroups();
-    network2->sortGroups();
 
     // simulate
     testSimulation1.simulate();
@@ -252,12 +239,6 @@ TEST_F(Continuous, Y_Network) {
     testSimulation1.set1DResistanceModel();
     testSimulation2.set1DResistanceModel();
 
-    // check if chips are valid
-    network1->isNetworkValid();
-    network2->isNetworkValid();
-    network1->sortGroups();
-    network2->sortGroups();
-
     // simulate
     testSimulation1.simulate();
     testSimulation2.simulate();
@@ -300,9 +281,6 @@ TEST_F(Continuous, Network2) {
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-   
-    network->sortGroups();
-    network->isNetworkValid();
 
     // Perform simulation and store results
     testSimulation->simulate();

--- a/tests/abstract/GradientGenerator.test.cpp
+++ b/tests/abstract/GradientGenerator.test.cpp
@@ -107,7 +107,6 @@ TEST_F(GradientGenerator, GradientGeneratorSmall) { // Result 50%
   network->setSink(sinkNode->getId());
 
   EXPECT_TRUE(network->isNetworkValid());
-  network->sortGroups();
 
   // fluids
   auto waterYellow = sim.addFluid(cContinuousPhaseViscosity, 1.56e3);
@@ -235,7 +234,6 @@ TEST_F(GradientGenerator, GradientGeneratorSmallDifferentPaper) { // Result Pape
   network->setSink(sinkNode->getId());
 
   EXPECT_TRUE(network->isNetworkValid());
-  network->sortGroups();
 
   // fluids
   auto waterYellow = sim.addFluid(cContinuousPhaseViscosity, 1.56e3);
@@ -431,7 +429,6 @@ TEST_F(GradientGenerator, GradientGeneratorUltraLargePaper) { // Paper 100%/88.6
   network->setSink(sinkNode->getId());
 
   EXPECT_TRUE(network->isNetworkValid());
-  network->sortGroups();
 
   // fluids
   auto waterYellow = sim.addFluid(cContinuousPhaseViscosity, 1.56e3 /* molecular size: 9e-10*/);

--- a/tests/abstract/InstantaneousMixing.test.cpp
+++ b/tests/abstract/InstantaneousMixing.test.cpp
@@ -69,11 +69,11 @@ TEST_F(InstantaneousMixing, Case1) {
     EXPECT_NEAR(result->getStates().at(3)->getMixturePositions().at(4).front().position1, 0.0, 1e-12);
     EXPECT_NEAR(result->getStates().at(3)->getMixturePositions().at(4).front().position2, 1.0, 1e-12);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 1);
 
-    EXPECT_NEAR(result->getMixtures().at(1)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(1)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0), 1e-7);
 }
 
 TEST_F(InstantaneousMixing, Case2) {
@@ -194,16 +194,16 @@ TEST_F(InstantaneousMixing, Case2) {
     EXPECT_NEAR(result->getStates().at(6)->getMixturePositions().at(4).front().position1, 0.0, 1e-12);
     EXPECT_NEAR(result->getStates().at(6)->getMixturePositions().at(4).front().position2, 1.0, 1e-12);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(2)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(3)->readSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(2)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(3)->getSpecieConcentrations().size(), 1);
 
-    EXPECT_NEAR(result->getMixtures().at(2)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0), 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(3)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0) + 
-        0.5*result->getMixtures().at(1)->readSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(2)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(3)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0) + 
+        0.5*result->getMixtures().at(1)->getSpecieConcentrations().at(0), 1e-7);
     
 }
 
@@ -575,21 +575,21 @@ TEST_F(InstantaneousMixing, Case8) {
     EXPECT_NEAR(result->getStates().at(6)->getTime(), 2.745356, 5e-7);
     EXPECT_NEAR(result->getStates().at(7)->getTime(), 3.216761, 5e-7);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 2);
-    EXPECT_EQ(result->getMixtures().at(2)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(3)->readSpecieConcentrations().size(), 2);
-    EXPECT_EQ(result->getMixtures().at(4)->readSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(2)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(3)->getSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(4)->getSpecieConcentrations().size(), 2);
 
-    EXPECT_NEAR(result->getMixtures().at(3)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0) +
-        0.5*result->getMixtures().at(1)->readSpecieConcentrations().at(0), 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(3)->readSpecieConcentrations().at(1), 
-        0.5*result->getMixtures().at(1)->readSpecieConcentrations().at(1), 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(4)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0), 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(4)->readSpecieConcentrations().at(1), 
-        0.5*result->getMixtures().at(2)->readSpecieConcentrations().at(1), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(3)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0) +
+        0.5*result->getMixtures().at(1)->getSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(3)->getSpecieConcentrations().at(1), 
+        0.5*result->getMixtures().at(1)->getSpecieConcentrations().at(1), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(4)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(4)->getSpecieConcentrations().at(1), 
+        0.5*result->getMixtures().at(2)->getSpecieConcentrations().at(1), 1e-7);
     
 
 }
@@ -640,14 +640,14 @@ TEST_F(InstantaneousMixing, Case9) {
     EXPECT_NEAR(result->getStates().at(8)->getTime(), 2.745356, 5e-7);
     EXPECT_NEAR(result->getStates().at(9)->getTime(), 2.856467, 5e-7);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(2)->readSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(2)->getSpecieConcentrations().size(), 1);
 
-    EXPECT_NEAR(result->getMixtures().at(1)->readSpecieConcentrations().at(0),
-        result->getMixtures().at(0)->readSpecieConcentrations().at(0)/3.0, 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(2)->readSpecieConcentrations().at(0),
-        result->getMixtures().at(0)->readSpecieConcentrations().at(0)/1.5, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(1)->getSpecieConcentrations().at(0),
+        result->getMixtures().at(0)->getSpecieConcentrations().at(0)/3.0, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(2)->getSpecieConcentrations().at(0),
+        result->getMixtures().at(0)->getSpecieConcentrations().at(0)/1.5, 1e-7);
 
 }
 
@@ -697,26 +697,26 @@ TEST_F(InstantaneousMixing, Case10) {
     EXPECT_NEAR(result->getStates().at(8)->getTime(), 2.745356, 5e-7);
     EXPECT_NEAR(result->getStates().at(9)->getTime(), 2.856467, 5e-7);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 2);
-    EXPECT_EQ(result->getMixtures().at(2)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(3)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(4)->readSpecieConcentrations().size(), 2);
-    EXPECT_EQ(result->getMixtures().at(5)->readSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(2)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(3)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(4)->getSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(5)->getSpecieConcentrations().size(), 2);
 
-    EXPECT_NEAR(result->getMixtures().at(3)->readSpecieConcentrations().at(0), 
-        result->getMixtures().at(0)->readSpecieConcentrations().at(0)/3.0, 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(4)->readSpecieConcentrations().at(0), 
-        result->getMixtures().at(0)->readSpecieConcentrations().at(0)/3.0 +
-        result->getMixtures().at(1)->readSpecieConcentrations().at(0)/3.0, 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(4)->readSpecieConcentrations().at(1), 
-        result->getMixtures().at(1)->readSpecieConcentrations().at(1)/3.0, 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(5)->readSpecieConcentrations().at(0), 
-        result->getMixtures().at(0)->readSpecieConcentrations().at(0)/3.0 +
-        result->getMixtures().at(1)->readSpecieConcentrations().at(0)/3.0, 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(5)->readSpecieConcentrations().at(1), 
-        result->getMixtures().at(1)->readSpecieConcentrations().at(1)/3.0 +
-        result->getMixtures().at(2)->readSpecieConcentrations().at(1)/3.0, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(3)->getSpecieConcentrations().at(0), 
+        result->getMixtures().at(0)->getSpecieConcentrations().at(0)/3.0, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(4)->getSpecieConcentrations().at(0), 
+        result->getMixtures().at(0)->getSpecieConcentrations().at(0)/3.0 +
+        result->getMixtures().at(1)->getSpecieConcentrations().at(0)/3.0, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(4)->getSpecieConcentrations().at(1), 
+        result->getMixtures().at(1)->getSpecieConcentrations().at(1)/3.0, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(5)->getSpecieConcentrations().at(0), 
+        result->getMixtures().at(0)->getSpecieConcentrations().at(0)/3.0 +
+        result->getMixtures().at(1)->getSpecieConcentrations().at(0)/3.0, 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(5)->getSpecieConcentrations().at(1), 
+        result->getMixtures().at(1)->getSpecieConcentrations().at(1)/3.0 +
+        result->getMixtures().at(2)->getSpecieConcentrations().at(1)/3.0, 1e-7);
 
 }
 
@@ -754,11 +754,11 @@ TEST_F(InstantaneousMixing, Case11) {
     EXPECT_NEAR(result->getStates().at(2)->getTime(), 0.745356, 5e-7);
     EXPECT_NEAR(result->getStates().at(3)->getTime(), 1.216761, 5e-7);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 1);
 
-    EXPECT_NEAR(result->getMixtures().at(1)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(1)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0), 1e-7);
 }
 
 TEST_F(InstantaneousMixing, Case12) {
@@ -797,15 +797,15 @@ TEST_F(InstantaneousMixing, Case12) {
     EXPECT_NEAR(result->getStates().at(3)->getTime(), 0.745356, 5e-7);
     EXPECT_NEAR(result->getStates().at(4)->getTime(), 1.216761, 5e-7);
 
-    EXPECT_EQ(result->getMixtures().at(0)->readSpecieConcentrations().size(), 1);
-    EXPECT_EQ(result->getMixtures().at(1)->readSpecieConcentrations().size(), 2);
-    EXPECT_EQ(result->getMixtures().at(2)->readSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(0)->getSpecieConcentrations().size(), 1);
+    EXPECT_EQ(result->getMixtures().at(1)->getSpecieConcentrations().size(), 2);
+    EXPECT_EQ(result->getMixtures().at(2)->getSpecieConcentrations().size(), 2);
 
-    EXPECT_NEAR(result->getMixtures().at(2)->readSpecieConcentrations().at(0), 
-        0.5*result->getMixtures().at(0)->readSpecieConcentrations().at(0) +
-        0.5*result->getMixtures().at(1)->readSpecieConcentrations().at(0), 1e-7);
-    EXPECT_NEAR(result->getMixtures().at(2)->readSpecieConcentrations().at(1), 
-        0.5*result->getMixtures().at(1)->readSpecieConcentrations().at(1), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(2)->getSpecieConcentrations().at(0), 
+        0.5*result->getMixtures().at(0)->getSpecieConcentrations().at(0) +
+        0.5*result->getMixtures().at(1)->getSpecieConcentrations().at(0), 1e-7);
+    EXPECT_NEAR(result->getMixtures().at(2)->getSpecieConcentrations().at(1), 
+        0.5*result->getMixtures().at(1)->getSpecieConcentrations().at(1), 1e-7);
 
 }
 

--- a/tests/abstract/InstantaneousMixing.test.cpp
+++ b/tests/abstract/InstantaneousMixing.test.cpp
@@ -18,10 +18,6 @@ TEST_F(InstantaneousMixing, Case1) {
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
 
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     sim->simulate();
 
@@ -90,10 +86,6 @@ TEST_F(InstantaneousMixing, Case2) {
 
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
-
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     sim->simulate();
@@ -226,10 +218,6 @@ TEST_F(InstantaneousMixing, Case3) {
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
 
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     sim->simulate();
 
@@ -301,10 +289,6 @@ TEST_F(InstantaneousMixing, Case4) {
 
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
-
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     sim->simulate();
@@ -438,10 +422,6 @@ TEST_F(InstantaneousMixing, Case5) {
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
 
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     sim->simulate();
 
@@ -479,10 +459,6 @@ TEST_F(InstantaneousMixing, Case6) {
 
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
-
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     sim->simulate();
@@ -530,10 +506,6 @@ TEST_F(InstantaneousMixing, Case7) {
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
 
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     sim->simulate();
 
@@ -571,10 +543,6 @@ TEST_F(InstantaneousMixing, Case8) {
 
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
-
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     sim->simulate();
@@ -637,10 +605,6 @@ TEST_F(InstantaneousMixing, Case9) {
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
 
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     sim->simulate();
 
@@ -697,10 +661,6 @@ TEST_F(InstantaneousMixing, Case10) {
 
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
-
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     sim->simulate();
@@ -771,10 +731,6 @@ TEST_F(InstantaneousMixing, Case11) {
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
 
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
-
     // simulate
     sim->simulate();
 
@@ -815,10 +771,6 @@ TEST_F(InstantaneousMixing, Case12) {
 
     // Load and set the simulations from the JSON files
     auto sim = porting::simulationFromJSON<T>(simFile, network);
-
-    // Check if network is valid
-    network->isNetworkValid();
-    network->sortGroups();
 
     // simulate
     sim->simulate();

--- a/tests/abstract/Tank.test.cpp
+++ b/tests/abstract/Tank.test.cpp
@@ -71,7 +71,6 @@ TEST_F(Tank, TwoTank) {
   auto pump0 = network->addFlowRatePump(node0->getId(), groundSinkNode->getId(), flowRate);
 
   EXPECT_TRUE(network->isNetworkValid());
-  network->sortGroups();
 
   // fluids
   auto continuousPhaseFluid = sim.addFluid(cContinuousPhaseViscosity, 0.993e3 /*molecular size: 9e-10, diffusivity: 4.4e-10, saturation: 0.0*/);

--- a/tests/hybrid/Hybrid.test.cpp
+++ b/tests/hybrid/Hybrid.test.cpp
@@ -74,15 +74,12 @@ TEST_F(Hybrid, Case1a) {
 
     testSimulation.addLbmSimulator(network->getCfdModule(m0->getId()), resolution, epsilon, tau, charPhysLength, charPhysVelocity, name);
     testSimulation.setNaiveHybridScheme(0.1, 0.5, 10);
-    network->sortGroups();
 
     // pressure pump
     auto pressure = 1e3;
     network->setPressurePump(c0->getId(), pressure);
     network->setPressurePump(c1->getId(), pressure);
     network->setPressurePump(c2->getId(), pressure);
-
-    network->isNetworkValid();
     
     // Simulate
     testSimulation.simulate();
@@ -119,8 +116,6 @@ TEST_F(Hybrid, esstest) {
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<float>(file, network);
 
-    network->isNetworkValid();
-
     // Simulate
     testSimulation->simulate();
 
@@ -156,8 +151,6 @@ TEST_F(Hybrid, Case1aJSON) {
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-
-    network->isNetworkValid();
     
     // Simulate
     testSimulation->simulate();
@@ -191,8 +184,6 @@ std::string file = "../examples/Hybrid/Network2a.JSON";
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-    
-    network->isNetworkValid();
 
     // Simulate
     testSimulation->simulate();
@@ -227,8 +218,6 @@ TEST_F(Hybrid, testCase3a) {
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-    
-    network->isNetworkValid();
 
     // Simulate
     testSimulation->simulate();
@@ -273,8 +262,6 @@ TEST_F(Hybrid, testCase4a) {
 
     // Load and set the simulation from a JSON file
     auto testSimulation = porting::simulationFromJSON<T>(file, network);
-    
-    network->isNetworkValid();
 
     // Simulate
     testSimulation->simulate();

--- a/tests/test_definitions.h
+++ b/tests/test_definitions.h
@@ -18,6 +18,8 @@ protected:
         sim::MixtureInjection<T>::resetMixtureInjectionCounter();
         sim::CFDSimulator<T>::resetSimulatorCounter();
     }
+
+    void sortGroups(std::shared_ptr<arch::Network<T>>& network) { network->sortGroups();}
 };
 
 template<typename T>

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -37,7 +37,7 @@ inline std::unordered_map<int, double> getAverageFluidConcentrationsInEdge(const
         auto position2 = mixturePosition.position2;
         auto mixtureLength = position2 - position1;
 
-        const auto& species = mixtures.at(mixtureId)->readSpecieConcentrations();
+        const auto& species = mixtures.at(mixtureId)->getSpecieConcentrations();
         for (const auto& [specieId, concentration]: species) {
             // percentage of channel filled with this mixture
             double newConcentration = concentration * mixtureLength;


### PR DESCRIPTION
## This PR updates

The :snake: python bindings for the new interface with improved :lock: encapsulation.

Besides that:
* :hammer: `network.isNetworkValid()` and `network.sortGroups()` are moved into `Simulation<T>.simulate()` and won't need to be called explicitly
* The :snake: python bindings are structured into separate binding functions and files
* Some `TODOS` are taken care of
* Fix some typos